### PR TITLE
use multiple access keys to prevent nonce conflicts

### DIFF
--- a/node/src/indexer/handler.rs
+++ b/node/src/indexer/handler.rs
@@ -73,7 +73,7 @@ async fn handle_message(
     streamer_message: near_indexer_primitives::StreamerMessage,
     stats: Arc<Mutex<IndexerStats>>,
     mpc_contract_id: &AccountId,
-    account_public_key: &Option<PublicKey>,
+    _account_public_key: &Option<PublicKey>,
     sign_request_sender: mpsc::Sender<ChainSignatureRequest>,
     indexer_state: Arc<IndexerState>,
 ) -> anyhow::Result<()> {
@@ -83,7 +83,7 @@ async fn handle_message(
     drop(stats_lock);
 
     let mut signature_requests = vec![];
-    let mut my_tx_nonces = vec![];
+    let my_tx_nonces = vec![];
 
     for shard in streamer_message.shards {
         for outcome in shard.receipt_execution_outcomes {
@@ -102,7 +102,9 @@ async fn handle_message(
                 });
             }
         }
-        if let Some(account_public_key) = account_public_key {
+
+        // TODO(#153): fix or remove this
+        /*if let Some(account_public_key) = account_public_key {
             if let Some(chunk) = &shard.chunk {
                 for tx in &chunk.transactions {
                     if tx.transaction.public_key == *account_public_key {
@@ -112,7 +114,7 @@ async fn handle_message(
                     }
                 }
             }
-        }
+        }*/
     }
 
     crate::metrics::MPC_INDEXER_LATEST_BLOCK_HEIGHT.set(block_height as i64);

--- a/node/src/indexer/response.rs
+++ b/node/src/indexer/response.rs
@@ -311,7 +311,7 @@ pub(crate) async fn handle_sign_responses(
                 tx_signer.clone(),
                 indexer_state.clone(),
                 response_ser,
-                Duration::from_secs(6), // TODO: maybe set the timeout and num_attempts in the config
+                Duration::from_secs(10), // TODO: maybe set the timeout and num_attempts in the config
                 NonZeroUsize::new(3).unwrap(),
             )
             .await;

--- a/node/src/indexer/response.rs
+++ b/node/src/indexer/response.rs
@@ -1,3 +1,4 @@
+use crate::config::RespondConfigFile;
 use crate::indexer::transaction::TransactionSigner;
 use crate::indexer::IndexerState;
 use crate::indexer::Nonce;
@@ -196,13 +197,16 @@ async fn submit_respond_tx(
         block.header.hash,
         block.header.height,
     );
-    tracing::info!(
-        target = "mpc",
-        "sending response tx {:?}",
-        transaction.get_hash()
-    );
 
     let nonce = transaction.transaction.nonce();
+    tracing::info!(
+        target = "mpc",
+        "sending response tx {:?} with ak={} nonce={}",
+        transaction.get_hash(),
+        tx_signer.public_key(),
+        nonce,
+    );
+
     let result = indexer_state
         .client
         .send(
@@ -274,14 +278,28 @@ async fn ensure_respond_tx(
 
 pub(crate) async fn handle_sign_responses(
     mut receiver: mpsc::Receiver<ChainRespondArgs>,
-    tx_signer: Option<Arc<TransactionSigner>>,
+    config: RespondConfigFile,
     indexer_state: Arc<IndexerState>,
 ) {
+    let mut signers = config
+        .access_keys
+        .iter()
+        .map(|key| {
+            Arc::new(TransactionSigner::from_key(
+                config.account_id.clone(),
+                key.clone(),
+            ))
+        })
+        .collect::<Vec<_>>()
+        .into_iter()
+        .cycle(); // Produces iterator cycling over the signers endlessly
+
     while let Some(respond_args) = receiver.recv().await {
-        let Some(tx_signer) = tx_signer.clone() else {
+        let Some(tx_signer) = signers.next() else {
             tracing::error!(target: "mpc", "Transaction signer unavailable; account secret key not provided");
             continue;
         };
+        let tx_signer = tx_signer.clone();
         let indexer_state = indexer_state.clone();
         actix::spawn(async move {
             let Ok(response_ser) = serde_json::to_string(&respond_args) else {

--- a/node/src/indexer/response.rs
+++ b/node/src/indexer/response.rs
@@ -311,8 +311,9 @@ pub(crate) async fn handle_sign_responses(
                 tx_signer.clone(),
                 indexer_state.clone(),
                 response_ser,
-                Duration::from_secs(10), // TODO: maybe set the timeout and num_attempts in the config
-                NonZeroUsize::new(3).unwrap(),
+                Duration::from_secs(10),
+                // TODO(#153): until nonce detection is fixed, this *must* be 1
+                NonZeroUsize::new(1).unwrap(),
             )
             .await;
         });

--- a/node/src/indexer/transaction.rs
+++ b/node/src/indexer/transaction.rs
@@ -1,4 +1,4 @@
-use near_crypto::{InMemorySigner, SecretKey, Signer};
+use near_crypto::{InMemorySigner, SecretKey, Signer, PublicKey};
 use near_indexer::near_primitives::account::AccessKey;
 use near_indexer_primitives::near_primitives::transaction::{
     FunctionCallAction, SignedTransaction, Transaction, TransactionV0,
@@ -60,5 +60,9 @@ impl TransactionSigner {
         let signature = self.signer.sign(tx_hash.as_ref());
 
         SignedTransaction::new(signature, transaction.clone())
+    }
+
+    pub(crate) fn public_key(&self) -> PublicKey {
+        self.signer.public_key()
     }
 }

--- a/node/src/indexer/transaction.rs
+++ b/node/src/indexer/transaction.rs
@@ -1,4 +1,4 @@
-use near_crypto::{InMemorySigner, SecretKey, Signer, PublicKey};
+use near_crypto::{InMemorySigner, PublicKey, SecretKey, Signer};
 use near_indexer::near_primitives::account::AccessKey;
 use near_indexer_primitives::near_primitives::transaction::{
     FunctionCallAction, SignedTransaction, Transaction, TransactionV0,


### PR DESCRIPTION
Implements #135.

Based on observations from the synthetic benchmark tooling, a node should use at least 1.3N keys if it wants to send N tx/s without nonce conflicts. 50 keys each on 8 nodes should be good for 300 sign requests per second. 

Given the large number of keys I chose to use a config file rather than pass them all in via an environment variable as we do for other secrets. The respond account doesn't have any special privileges so risks are lower here. Not sure exactly what would be best practice though, so open to suggestions.

The pytest gains a flag configuring the number of access keys. I confirmed via logs and via near-cli inspection that nodes spread their txs across their access keys as expected. I'm not sure I've actually managed to produce a nonce conflict in localnet even when using only one access key; I think the network setup is too simple and consistent to see reordering.