### PR TITLE
Support keyshare storage in GCP and local, natively.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,32 +794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47bb8cc16b669d267eeccf585aea077d0882f4777b1c1f740217885d6e6e5a3"
-dependencies = [
- "aws-lc-sys",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2101df3813227bbaaaa0b04cd61c534c7954b22bd68d399b440be937dc63ff7"
-dependencies = [
- "bindgen 0.69.5",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "libc",
- "paste",
-]
-
-[[package]]
 name = "aws-region"
 version = "0.25.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,7 +843,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "itoa",
  "matchit",
@@ -994,29 +981,6 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.90",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.90",
- "which",
 ]
 
 [[package]]
@@ -1428,7 +1392,7 @@ dependencies = [
  "dotenv",
  "futures-util",
  "hex",
- "jsonwebtoken",
+ "jsonwebtoken 7.2.0",
  "lazy_static",
  "openssl",
  "percent-encoding",
@@ -1445,15 +1409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2013,12 +1968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,12 +2359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,6 +2479,34 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gcloud-sdk"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a771db7ee43ad84638d0e6131cb514e402af6a5a96051f4425d66dc0ee527d8"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "hyper 1.5.2",
+ "jsonwebtoken 9.3.0",
+ "once_cell",
+ "prost 0.13.4",
+ "prost-types",
+ "reqwest 0.12.9",
+ "secret-vault-value",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic 0.12.3",
+ "tower 0.5.1",
+ "tower-layer",
+ "tower-util",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2843,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2864,19 +2835,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2889,6 +2861,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.5.2",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -2912,7 +2897,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2931,7 +2916,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2 0.5.8",
  "tokio",
@@ -3270,7 +3255,22 @@ dependencies = [
  "ring 0.16.20",
  "serde",
  "serde_json",
- "simple_asn1",
+ "simple_asn1 0.4.1",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem 3.0.4",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
+ "simple_asn1 0.6.3",
 ]
 
 [[package]]
@@ -3362,7 +3362,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen 0.65.1",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "glob",
@@ -3691,6 +3691,7 @@ dependencies = [
  "flume",
  "futures",
  "futures-util",
+ "gcloud-sdk",
  "hex",
  "hex-literal",
  "hkdf",
@@ -4332,7 +4333,7 @@ dependencies = [
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
- "pin-project",
+ "pin-project 1.1.7",
  "protobuf 3.7.1",
  "protobuf-codegen",
  "rand",
@@ -5329,10 +5330,10 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.12.6",
  "thiserror 1.0.69",
  "tokio",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -5343,8 +5344,8 @@ checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic",
+ "prost 0.12.6",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -5617,11 +5618,31 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.1.7",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5862,7 +5883,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.4",
 ]
 
 [[package]]
@@ -5876,6 +5907,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+dependencies = [
+ "prost 0.13.4",
 ]
 
 [[package]]
@@ -6004,6 +6057,58 @@ dependencies = [
  "byteorder",
  "log",
  "parity-wasm 0.41.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.0",
+ "rustls",
+ "socket2 0.5.8",
+ "thiserror 2.0.4",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+dependencies = [
+ "bytes",
+ "getrandom",
+ "rand",
+ "ring 0.17.8",
+ "rustc-hash 2.1.0",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.4",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.8",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6313,6 +6418,7 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -6322,7 +6428,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -6330,11 +6436,15 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6342,11 +6452,15 @@ dependencies = [
  "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "windows-registry",
 ]
 
@@ -6625,9 +6739,9 @@ version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
+ "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -6657,6 +6771,9 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -6664,7 +6781,6 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -6794,6 +6910,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-vault-value"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc32a777b53b3433b974c9c26b6d502a50037f8da94e46cb8ce2ced2cfdfaea0"
+dependencies = [
+ "prost 0.13.4",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6808,9 +6937,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7112,6 +7241,18 @@ dependencies = [
  "chrono",
  "num-bigint 0.2.6",
  "num-traits",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "thiserror 2.0.4",
+ "time",
 ]
 
 [[package]]
@@ -7729,16 +7870,49 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
- "pin-project",
- "prost",
+ "pin-project 1.1.7",
+ "prost 0.12.6",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-timeout 0.5.2",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project 1.1.7",
+ "prost 0.13.4",
+ "rustls-pemfile 2.2.0",
+ "socket2 0.5.8",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -7750,7 +7924,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap 1.9.3",
- "pin-project",
+ "pin-project 1.1.7",
  "pin-project-lite",
  "rand",
  "slab",
@@ -7788,6 +7962,18 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.30",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"
@@ -8561,6 +8747,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/deployment/gcp-start.sh
+++ b/deployment/gcp-start.sh
@@ -28,8 +28,6 @@ echo Using GCP_ACCOUNT_SK_SECRET_ID=${GCP_ACCOUNT_SK_SECRET_ID:?"GCP_ACCOUNT_SK_
 
 # Note that other non-secret configurations are passed in config.yaml.
 
-echo "Fetching keyshare from GCP secret manager..."
-KEYSHARE=$(gcloud secrets versions access latest --project $GCP_PROJECT_ID --secret=$GCP_KEYSHARE_SECRET_ID)
 echo "Fetching local encryption key from GCP secret manager..."
 LOCAL_ENCRYPTION_KEY=$(gcloud secrets versions access latest --project $GCP_PROJECT_ID --secret=$GCP_LOCAL_ENCRYPTION_KEY_SECRET_ID)
 echo "Fetching P2P private key from GCP secret manager..."
@@ -38,7 +36,8 @@ echo "Fetching account secret key from GCP secret manager..."
 ACCOUNT_SK=$(gcloud secrets versions access latest --project $GCP_PROJECT_ID --secret=$GCP_ACCOUNT_SK_SECRET_ID)
 
 echo "Starting mpc node..."
-MPC_ROOT_KEYSHARE="${KEYSHARE}" \
+GCP_PROJECT_ID="${GCP_PROJECT_ID}" \
+GCP_KEYSHARE_SECRET_ID="${GCP_KEYSHARE_SECRET_ID}" \
 MPC_SECRET_STORE_KEY=${LOCAL_ENCRYPTION_KEY} \
 MPC_P2P_PRIVATE_KEY=${P2P_PRIVATE_KEY} \
 MPC_ACCOUNT_SK=${ACCOUNT_SK} \

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"
 futures-util = "0.3.31"
+gcloud-sdk = { version = "0.26.2", default-features = false, features = ["google-cloud-secretmanager-v1", "tls-webpki-roots"] }
 hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.4.1"
 hkdf = "0.12.4"
@@ -28,7 +29,7 @@ rand = "0.8.5"
 rand_xorshift = "0.3"
 rcgen = "0.13.1"
 rocksdb = "0.21.0"
-rustls = { version = "0.23.16" }
+rustls = { version = "0.23.16", default-features = false }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
 serde_yaml = "0.9.34"
@@ -36,7 +37,7 @@ sha3 = "0.10.8"
 tempfile = "3.14.0"
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-util = "0.7.12"
-tokio-rustls = "0.26.1"
+tokio-rustls = { version = "0.26.1", default-features = false }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -11,9 +11,10 @@ use crate::indexer::response::handle_sign_responses;
 use crate::indexer::stats::{indexer_logger, IndexerStats};
 use crate::indexer::transaction::TransactionSigner;
 use crate::indexer::IndexerState;
-use crate::key_generation::{
-    affine_point_to_public_key, load_root_keyshare, run_key_generation_client,
-};
+use crate::key_generation::{affine_point_to_public_key, run_key_generation_client};
+use crate::keyshare::gcp::GcpKeyshareStorage;
+use crate::keyshare::local::LocalKeyshareStorage;
+use crate::keyshare::KeyshareStorage;
 use crate::mpc_client::MpcClient;
 use crate::network::{run_network_client, MeshNetworkTransportSender};
 use crate::p2p::{generate_test_p2p_configs, new_tls_mesh_network};
@@ -32,6 +33,7 @@ use near_crypto::SecretKey;
 use near_indexer_primitives::types::{AccountId, Finality};
 use near_time::Clock;
 use std::num::NonZero;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -43,29 +45,7 @@ use tokio::sync::{Mutex, OnceCell};
 pub enum Cli {
     /// Runs the node in normal operating mode. A root keyshare must already
     /// exist on disk.
-    Start {
-        #[arg(long, env("MPC_HOME_DIR"))]
-        home_dir: String,
-        /// Hex-encoded 16 byte AES key for local storage encryption.
-        /// This key should come from a secure secret storage.
-        #[arg(env("MPC_SECRET_STORE_KEY"))]
-        secret_store_key_hex: String,
-        /// Root keyshare, if this is being passed in rather than loaded from disk.
-        /// This should be used if the root keyshare is being stored with a secret
-        /// manager (such as Google Secret Manager) instead of encrypted on disk.
-        /// A bash script should be used to first read the root keyshare from the
-        /// secret manager, and then pass it in via this argument.
-        /// The root keyshare should be passed in as a JSON string.
-        #[arg(env("MPC_ROOT_KEYSHARE"))]
-        root_keyshare: Option<String>,
-        /// p2p private key for TLS. It must be in the format of "ed25519:...".
-        #[arg(env("MPC_P2P_PRIVATE_KEY"))]
-        p2p_private_key: SecretKey,
-        /// Near account secret key. Signing transactions will only be posted to the
-        /// contract if this is specified.
-        #[arg(env("MPC_ACCOUNT_SK"))]
-        account_secret_key: Option<SecretKey>,
-    },
+    Start(StartCmd),
     /// Generates the root keyshare. This will only succeed if all participants
     /// run this command together, as in, every node will wait for the full set
     /// of participants before generating.
@@ -97,6 +77,29 @@ pub enum Cli {
     GenerateIndexerConfigs(InitConfigArgs),
 }
 
+#[derive(Parser, Debug)]
+pub struct StartCmd {
+    #[arg(long, env("MPC_HOME_DIR"))]
+    pub home_dir: String,
+    /// Hex-encoded 16 byte AES key for local storage encryption.
+    /// This key should come from a secure secret storage.
+    #[arg(env("MPC_SECRET_STORE_KEY"))]
+    pub secret_store_key_hex: String,
+    /// If provided, the root keyshare is stored on GCP.
+    /// This requires GCP_PROJECT_ID to be set as well.
+    #[arg(env("GCP_KEYSHARE_SECRET_ID"))]
+    pub gcp_keyshare_secret_id: Option<String>,
+    #[arg(env("GCP_PROJECT_ID"))]
+    pub gcp_project_id: Option<String>,
+    /// p2p private key for TLS. It must be in the format of "ed25519:...".
+    #[arg(env("MPC_P2P_PRIVATE_KEY"))]
+    pub p2p_private_key: SecretKey,
+    /// Near account secret key. Signing transactions will only be posted to the
+    /// contract if this is specified.
+    #[arg(env("MPC_ACCOUNT_SK"))]
+    pub account_secret_key: Option<SecretKey>,
+}
+
 /// Tokio Runtime cannot be dropped in an asynchronous context (for good reason).
 /// However, we need to be able to drop it in two scenarios:
 ///  - Integration tests, where we want to start up and shut down the CLI
@@ -121,6 +124,14 @@ impl AsyncDroppableRuntime {
     }
 }
 
+impl Deref for AsyncDroppableRuntime {
+    type Target = tokio::runtime::Runtime;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref().unwrap()
+    }
+}
+
 impl Drop for AsyncDroppableRuntime {
     fn drop(&mut self) {
         if let Some(runtime) = self.0.take() {
@@ -131,31 +142,47 @@ impl Drop for AsyncDroppableRuntime {
     }
 }
 
+async fn make_keyshare_storage(
+    home_dir: PathBuf,
+    local_encryption_key: [u8; 16],
+    secret_id: Option<String>,
+    project_id: Option<String>,
+) -> anyhow::Result<Box<dyn KeyshareStorage>> {
+    match (secret_id, project_id) {
+        (Some(secret_id), Some(project_id)) => {
+            let storage = GcpKeyshareStorage::new(project_id, secret_id).await?;
+            Ok(Box::new(storage))
+        }
+        (None, None) => {
+            let storage = LocalKeyshareStorage::new(home_dir, local_encryption_key);
+            Ok(Box::new(storage))
+        }
+        _ => {
+            anyhow::bail!(
+                "Both GCP_SECRET_ID and GCP_PROJECT_ID must be set to use GCP secrets storage"
+            );
+        }
+    }
+}
+
 struct StartResponse {
     _mpc_runtime: AsyncDroppableRuntime,
     mpc_task: AutoAbortTask<Result<(), anyhow::Error>>,
     indexer_handle: Option<JoinHandle<()>>,
 }
 
-impl Cli {
-    fn start(
-        home_dir: String,
-        secret_store_key_hex: String,
-        root_keyshare: Option<String>,
-        p2p_private_key: SecretKey,
-        account_secret_key: Option<SecretKey>,
-    ) -> anyhow::Result<StartResponse> {
-        let home_dir = PathBuf::from(home_dir);
-        let secrets = SecretsConfig::from_cli(&secret_store_key_hex, p2p_private_key)?;
+impl StartCmd {
+    fn run(self) -> anyhow::Result<StartResponse> {
+        let home_dir = PathBuf::from(self.home_dir);
+        let secrets = SecretsConfig::from_cli(&self.secret_store_key_hex, self.p2p_private_key)?;
         let config = ConfigFile::from_file(&home_dir.join("config.yaml"))?;
-        let root_keyshare =
-            load_root_keyshare(&home_dir, secrets.local_storage_aes_key, &root_keyshare)?;
 
         let (chain_config_sender, mut chain_config_receiver) = mpsc::channel(10);
         let (sign_request_sender, sign_request_receiver) = mpsc::channel(10000);
         let (sign_response_sender, sign_response_receiver) = mpsc::channel(10000);
 
         // Start the near indexer
+        let account_secret_key = self.account_secret_key;
         let indexer_handle = config.indexer.clone().map(|indexer_config| {
             let config = config.clone();
             let home_dir = home_dir.clone();
@@ -222,6 +249,7 @@ impl Cli {
         } else {
             tokio::runtime::Runtime::new()?
         };
+        let mpc_runtime = AsyncDroppableRuntime::new(mpc_runtime);
 
         let root_mpc_future = async move {
             let root_task_handle = tracking::current_task();
@@ -238,6 +266,18 @@ impl Cli {
             #[cfg(not(test))]
             let web_server = start_web_server(root_task_handle, config.web_ui.clone()).await?;
             let _web_server_handle = tracking::spawn("web server", web_server);
+
+            let keyshare_storage = make_keyshare_storage(
+                home_dir.clone(),
+                secrets.local_storage_aes_key,
+                self.gcp_keyshare_secret_id,
+                self.gcp_project_id,
+            )
+            .await?;
+            let root_keyshare = keyshare_storage
+                .load()
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Root keyshare not found"))?;
 
             // Replace participants in config with those listed in the smart contract state
             let participants = if config.indexer.is_some() {
@@ -341,28 +381,18 @@ impl Cli {
         }));
 
         Ok(StartResponse {
-            _mpc_runtime: AsyncDroppableRuntime::new(mpc_runtime),
+            _mpc_runtime: mpc_runtime,
             mpc_task,
             indexer_handle,
         })
     }
+}
 
+impl Cli {
     pub async fn run(self) -> anyhow::Result<()> {
         match self {
-            Cli::Start {
-                home_dir,
-                secret_store_key_hex,
-                root_keyshare,
-                p2p_private_key,
-                account_secret_key,
-            } => {
-                let start_response = Self::start(
-                    home_dir,
-                    secret_store_key_hex,
-                    root_keyshare,
-                    p2p_private_key,
-                    account_secret_key,
-                )?;
+            Cli::Start(start) => {
+                let start_response = start.run()?;
                 if let Some(indexer_handle) = start_response.indexer_handle {
                     indexer_handle
                         .join()
@@ -388,6 +418,7 @@ impl Cli {
                 } else {
                     tokio::runtime::Runtime::new()?
                 };
+                let mpc_runtime = AsyncDroppableRuntime::new(mpc_runtime);
                 // TODO(#75): Support reading from smart contract state here as well.
                 let mpc_config = MpcConfig::from_participants_with_near_account_id(
                     config
@@ -425,9 +456,12 @@ impl Cli {
                             let (network_client, channel_receiver, _handle) =
                                 run_network_client(Arc::new(sender), Box::new(receiver));
                             run_key_generation_client(
-                                PathBuf::from(home_dir),
-                                config.into(),
+                                config.mpc.clone().into(),
                                 network_client,
+                                Box::new(LocalKeyshareStorage::new(
+                                    PathBuf::from(home_dir),
+                                    config.secrets.local_storage_aes_key,
+                                )),
                                 channel_receiver,
                             )
                             .await?;
@@ -436,7 +470,6 @@ impl Cli {
                         root_task.await
                     })
                     .await??;
-                drop(AsyncDroppableRuntime::new(mpc_runtime));
                 Ok(())
             }
             Cli::GenerateTestConfigs {

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -40,7 +40,7 @@ pub struct SignatureConfig {
 
 /// Configuration about the MPC protocol. It can come from either the contract
 /// on chain, or static offline config file.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MpcConfig {
     pub my_participant_id: ParticipantId,
     pub participants: ParticipantsConfig,

--- a/node/src/key_generation.rs
+++ b/node/src/key_generation.rs
@@ -1,17 +1,13 @@
-use crate::config::Config;
-use crate::db;
+use crate::config::MpcConfig;
+use crate::keyshare::{KeyshareStorage, RootKeyshareData};
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::{MpcTaskId, ParticipantId};
 use crate::protocol::run_protocol;
-use aes_gcm::aead::generic_array::GenericArray;
-use aes_gcm::{Aes128Gcm, KeyInit};
 use anyhow::Context;
 use cait_sith::protocol::Participant;
 use cait_sith::KeygenOutput;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
-use k256::{AffinePoint, Scalar, Secp256k1};
-use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use k256::{AffinePoint, Secp256k1};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
@@ -32,86 +28,22 @@ pub async fn run_key_generation(
     run_protocol("key generation", channel, me, protocol).await
 }
 
-/// The root keyshare data along with an epoch. The epoch is incremented
-/// for each key resharing. This is the format stored in the old MPC
-/// implementation, and we're keeping it the same to ease migration.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct RootKeyshareData {
-    pub epoch: u64,
-    pub private_share: Scalar,
-    pub public_key: AffinePoint,
-}
-
-impl RootKeyshareData {
-    pub fn keygen_output(&self) -> KeygenOutput<Secp256k1> {
-        KeygenOutput {
-            private_share: self.private_share,
-            public_key: self.public_key,
-        }
-    }
-
-    pub fn of_epoch_zero(keygen_output: KeygenOutput<Secp256k1>) -> Self {
-        Self {
-            epoch: 0,
-            private_share: keygen_output.private_share,
-            public_key: keygen_output.public_key,
-        }
-    }
-}
-
-/// Reads the root keyshare (keygen output) from disk.
-pub fn load_root_keyshare(
-    home_dir: &Path,
-    encryption_key: [u8; 16],
-    root_keyshare_override: &Option<String>,
-) -> anyhow::Result<RootKeyshareData> {
-    if let Some(override_key) = root_keyshare_override {
-        return serde_json::from_str(override_key)
-            .with_context(|| format!("Failed to parse root keyshare: {}", override_key));
-    }
-    let key_path = home_dir.join("key");
-    let cipher = Aes128Gcm::new(GenericArray::from_slice(&encryption_key));
-    let data = std::fs::read(key_path).context("Failed to read keygen file")?;
-    let decrypted = db::decrypt(&cipher, &data).context("Failed to decrypt keygen")?;
-    serde_json::from_slice(&decrypted).context("Failed to parse keygen")
-}
-
-/// Saves the root keyshare (keygen output) to disk.
-fn save_root_keyshare(
-    home_dir: &Path,
-    encryption_key: [u8; 16],
-    root_keyshare: &RootKeyshareData,
-) -> anyhow::Result<()> {
-    assert_root_key_does_not_exist(home_dir);
-    let key_path = home_dir.join("key");
-    let cipher = Aes128Gcm::new(GenericArray::from_slice(&encryption_key));
-    let data = serde_json::to_vec(&root_keyshare).context("Failed to serialize keygen")?;
-    let encrypted = db::encrypt(&cipher, &data);
-    std::fs::write(key_path, &encrypted).context("Failed to write keygen file")
-}
-
-/// Panics if the root keyshare file already exists.
-fn assert_root_key_does_not_exist(home_dir: &Path) {
-    if home_dir.join("key").exists() {
-        panic!("Root keyshare file already exists; refusing to overwrite");
-    }
-}
-
 /// Performs the key generation protocol, saving the keyshare to disk.
 /// Returns when the key generation is complete or runs into an error.
 /// This is expected to only succeed if all participants are online
 /// and running this function.
 pub async fn run_key_generation_client(
-    home_dir: PathBuf,
-    config: Arc<Config>,
+    config: Arc<MpcConfig>,
     client: Arc<MeshNetworkClient>,
+    keyshare_storage: Box<dyn KeyshareStorage>,
     mut channel_receiver: mpsc::Receiver<NetworkTaskChannel>,
 ) -> anyhow::Result<()> {
-    assert_root_key_does_not_exist(&home_dir);
+    if keyshare_storage.load().await?.is_some() {
+        anyhow::bail!("Keyshare already exists, refusing to run key generation");
+    }
     let my_participant_id = client.my_participant_id();
     let is_leader = my_participant_id
         == config
-            .mpc
             .participants
             .participants
             .iter()
@@ -134,14 +66,12 @@ pub async fn run_key_generation_client(
     let key = run_key_generation(
         channel,
         my_participant_id,
-        config.mpc.participants.threshold as usize,
+        config.participants.threshold as usize,
     )
     .await?;
-    save_root_keyshare(
-        &home_dir,
-        config.secrets.local_storage_aes_key,
-        &RootKeyshareData::of_epoch_zero(key.clone()),
-    )?;
+    keyshare_storage
+        .store(&RootKeyshareData::new(0, key.clone()))
+        .await?;
     tracing::info!("Key generation completed");
 
     // TODO(#75): Send vote_pk transaction to vote for the public key on the contract.
@@ -160,12 +90,10 @@ pub fn affine_point_to_public_key(point: AffinePoint) -> anyhow::Result<near_cry
 
 #[cfg(test)]
 mod tests {
-    use super::{run_key_generation, save_root_keyshare};
-    use crate::key_generation::RootKeyshareData;
+    use super::run_key_generation;
     use crate::network::testing::run_test_clients;
     use crate::network::{MeshNetworkClient, NetworkTaskChannel};
     use crate::primitives::MpcTaskId;
-    use crate::tests::TestGenerators;
     use crate::tracking::testing::start_root_task_with_periodic_dump;
     use cait_sith::KeygenOutput;
     use k256::Secp256k1;
@@ -200,27 +128,5 @@ mod tests {
         let key = run_key_generation(channel, participant_id, 3).await?;
 
         Ok(key)
-    }
-
-    #[test]
-    fn test_keygen_store() {
-        let dir = tempfile::tempdir().unwrap();
-        let encryption_key = [1; 16];
-        let generated_key = TestGenerators::new(2, 2)
-            .make_keygens()
-            .into_iter()
-            .next()
-            .unwrap()
-            .1;
-
-        save_root_keyshare(
-            dir.path(),
-            encryption_key,
-            &RootKeyshareData::of_epoch_zero(generated_key.clone()),
-        )
-        .unwrap();
-        let loaded_key = super::load_root_keyshare(dir.path(), encryption_key, &None).unwrap();
-        assert_eq!(generated_key.private_share, loaded_key.private_share);
-        assert_eq!(generated_key.public_key, loaded_key.public_key);
     }
 }

--- a/node/src/keyshare/gcp.rs
+++ b/node/src/keyshare/gcp.rs
@@ -19,7 +19,7 @@ impl GcpKeyshareStorage {
     pub async fn new(project_id: String, secret_id: String) -> anyhow::Result<Self> {
         let secrets_client = GoogleApi::from_function(
             SecretManagerServiceClient::new,
-            "https://secretmanager.googleapis.com/",
+            "https://secretmanager.googleapis.com",
             None,
         )
         .await

--- a/node/src/keyshare/gcp.rs
+++ b/node/src/keyshare/gcp.rs
@@ -1,0 +1,101 @@
+use super::{KeyshareStorage, RootKeyshareData};
+use anyhow::Context;
+use gcloud_sdk::google::cloud::secretmanager::v1::secret_manager_service_client::SecretManagerServiceClient;
+use gcloud_sdk::google::cloud::secretmanager::v1::secret_version::State;
+use gcloud_sdk::google::cloud::secretmanager::v1::{
+    AccessSecretVersionRequest, AddSecretVersionRequest, ListSecretVersionsRequest,
+};
+use gcloud_sdk::proto_ext::secretmanager::SecretPayload;
+use gcloud_sdk::{GoogleApi, GoogleAuthMiddleware, SecretValue};
+
+/// Keyshare storage that loads and stores the key from Google Secret Manager.
+pub struct GcpKeyshareStorage {
+    secrets_client: GoogleApi<SecretManagerServiceClient<GoogleAuthMiddleware>>,
+    project_id: String,
+    secret_id: String,
+}
+
+impl GcpKeyshareStorage {
+    pub async fn new(project_id: String, secret_id: String) -> anyhow::Result<Self> {
+        let secrets_client = GoogleApi::from_function(
+            SecretManagerServiceClient::new,
+            "https://secretmanager.googleapis.com/",
+            None,
+        )
+        .await
+        .context("Failed to create SecretManagerServiceClient")?;
+
+        Ok(Self {
+            secrets_client,
+            project_id,
+            secret_id,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl KeyshareStorage for GcpKeyshareStorage {
+    async fn load(&self) -> anyhow::Result<Option<RootKeyshareData>> {
+        let secret_name = format!("projects/{}/secrets/{}", self.project_id, self.secret_id);
+        let versions = self
+            .secrets_client
+            .get()
+            .list_secret_versions(ListSecretVersionsRequest {
+                parent: secret_name,
+                ..Default::default()
+            })
+            .await
+            .context("Failed to list secret versions")?
+            .into_inner();
+
+        let Some(latest_version) = versions
+            .versions
+            .into_iter()
+            .find(|version| version.state() == State::Enabled)
+        else {
+            return Ok(None);
+        };
+        let secret = self
+            .secrets_client
+            .get()
+            .access_secret_version(AccessSecretVersionRequest {
+                name: latest_version.name,
+            })
+            .await
+            .context("Failed to access secret version")?
+            .into_inner()
+            .payload
+            .ok_or_else(|| anyhow::anyhow!("Secret version has no payload"))?;
+
+        let keyshare: RootKeyshareData = serde_json::from_slice(secret.data.as_sensitive_bytes())
+            .context("Failed to parse keygen")?;
+        Ok(Some(keyshare))
+    }
+
+    async fn store(&self, root_keyshare: &RootKeyshareData) -> anyhow::Result<()> {
+        let existing = self.load().await.context("Checking existing keyshare")?;
+        if let Some(existing) = existing {
+            if existing.epoch >= root_keyshare.epoch {
+                return Err(anyhow::anyhow!(
+                    "Refusing to overwrite existing keyshare of epoch {} with new keyshare of older epoch {}",
+                    existing.epoch,
+                    root_keyshare.epoch,
+                ));
+            }
+        }
+        let secret_name = format!("projects/{}/secrets/{}", self.project_id, self.secret_id);
+        let data = serde_json::to_vec(&root_keyshare).context("Failed to serialize keygen")?;
+        self.secrets_client
+            .get()
+            .add_secret_version(AddSecretVersionRequest {
+                parent: secret_name,
+                payload: Some(SecretPayload {
+                    data: SecretValue::new(data),
+                    ..Default::default()
+                }),
+            })
+            .await
+            .context("Failed to create secret version")?;
+        Ok(())
+    }
+}

--- a/node/src/keyshare/local.rs
+++ b/node/src/keyshare/local.rs
@@ -1,0 +1,127 @@
+use super::{KeyshareStorage, RootKeyshareData};
+use crate::db;
+use aes_gcm::{Aes128Gcm, KeyInit};
+use anyhow::Context;
+use sha3::digest::generic_array::GenericArray;
+use std::path::PathBuf;
+
+/// Stores the root keyshare in a local encrypted file.
+pub struct LocalKeyshareStorage {
+    home_dir: PathBuf,
+    encryption_key: [u8; 16],
+}
+
+impl LocalKeyshareStorage {
+    pub fn new(home_dir: PathBuf, key: [u8; 16]) -> Self {
+        Self {
+            home_dir,
+            encryption_key: key,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl KeyshareStorage for LocalKeyshareStorage {
+    async fn load(&self) -> anyhow::Result<Option<RootKeyshareData>> {
+        let cipher = Aes128Gcm::new(GenericArray::from_slice(&self.encryption_key));
+        let keyfile = self.home_dir.join("key");
+        if !keyfile.exists() {
+            return Ok(None);
+        }
+        let data = tokio::fs::read(keyfile)
+            .await
+            .context("Failed to read keygen file")?;
+        let decrypted = db::decrypt(&cipher, &data).context("Failed to decrypt keygen")?;
+        let keyshare: RootKeyshareData =
+            serde_json::from_slice(&decrypted).context("Failed to parse keygen")?;
+        Ok(Some(keyshare))
+    }
+
+    async fn store(&self, root_keyshare: &RootKeyshareData) -> anyhow::Result<()> {
+        let existing = self.load().await.context("Checking existing keyshare")?;
+        if let Some(existing) = existing {
+            if existing.epoch >= root_keyshare.epoch {
+                return Err(anyhow::anyhow!(
+                    "Refusing to overwrite existing keyshare of epoch {} with new keyshare of older epoch {}",
+                    existing.epoch,
+                    root_keyshare.epoch,
+                ));
+            }
+        }
+        let cipher = Aes128Gcm::new(GenericArray::from_slice(&self.encryption_key));
+        let data = serde_json::to_vec(&root_keyshare).context("Failed to serialize keygen")?;
+        let encrypted = db::encrypt(&cipher, &data);
+        // Write the new key to a separate file, and then create a link to it.
+        // That way there is no risk of corrupting the previous keyshare if the write is interrupted.
+        let keyfile_for_epoch = self.home_dir.join(format!("key_{}", root_keyshare.epoch));
+        tokio::fs::write(&keyfile_for_epoch, &encrypted)
+            .await
+            .context("Failed to write keygen file")?;
+        let keyfile = self.home_dir.join("key");
+        tokio::fs::remove_file(&keyfile).await.ok();
+        tokio::fs::hard_link(&keyfile_for_epoch, &keyfile)
+            .await
+            .context("Failed to link keygen file")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::keyshare::local::LocalKeyshareStorage;
+    use crate::keyshare::{KeyshareStorage, RootKeyshareData};
+    use crate::tests::TestGenerators;
+
+    #[tokio::test]
+    async fn test_local_keyshare_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let encryption_key = [1; 16];
+        let generated_key = TestGenerators::new(2, 2)
+            .make_keygens()
+            .into_iter()
+            .next()
+            .unwrap()
+            .1;
+
+        let storage = LocalKeyshareStorage::new(dir.path().to_path_buf(), encryption_key);
+        assert!(storage.load().await.unwrap().is_none());
+        storage
+            .store(&RootKeyshareData::new(0, generated_key.clone()))
+            .await
+            .unwrap();
+        let loaded_key = storage.load().await.unwrap().unwrap();
+        assert_eq!(generated_key.private_share, loaded_key.private_share);
+        assert_eq!(generated_key.public_key, loaded_key.public_key);
+
+        let generated_key_2 = TestGenerators::new(3, 2)
+            .make_keygens()
+            .into_iter()
+            .next()
+            .unwrap()
+            .1;
+        // Can't store unless epoch is higher.
+        assert!(storage
+            .store(&RootKeyshareData::new(0, generated_key_2.clone()))
+            .await
+            .is_err());
+
+        // Can store if epoch is higher.
+        storage
+            .store(&RootKeyshareData::new(1, generated_key_2.clone()))
+            .await
+            .unwrap();
+        let loaded_key_2 = storage.load().await.unwrap().unwrap();
+        assert_eq!(generated_key_2.private_share, loaded_key_2.private_share);
+        assert_eq!(generated_key_2.public_key, loaded_key_2.public_key);
+
+        // Can't store unless epoch is higher.
+        assert!(storage
+            .store(&RootKeyshareData::new(1, generated_key.clone()))
+            .await
+            .is_err());
+        assert!(storage
+            .store(&RootKeyshareData::new(0, generated_key))
+            .await
+            .is_err());
+    }
+}

--- a/node/src/keyshare/mod.rs
+++ b/node/src/keyshare/mod.rs
@@ -1,0 +1,46 @@
+pub mod gcp;
+pub mod local;
+
+use cait_sith::KeygenOutput;
+use k256::{AffinePoint, Scalar, Secp256k1};
+use serde::{Deserialize, Serialize};
+
+/// The root keyshare data along with an epoch. The epoch is incremented
+/// for each key resharing. This is the format stored in the old MPC
+/// implementation, and we're keeping it the same to ease migration.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct RootKeyshareData {
+    pub epoch: u64,
+    pub private_share: Scalar,
+    pub public_key: AffinePoint,
+}
+
+impl RootKeyshareData {
+    pub fn keygen_output(&self) -> KeygenOutput<Secp256k1> {
+        KeygenOutput {
+            private_share: self.private_share,
+            public_key: self.public_key,
+        }
+    }
+
+    pub fn new(epoch: u64, keygen_output: KeygenOutput<Secp256k1>) -> Self {
+        Self {
+            epoch,
+            private_share: keygen_output.private_share,
+            public_key: keygen_output.public_key,
+        }
+    }
+}
+
+/// Abstracts away the storage of the root keyshare data.
+#[async_trait::async_trait]
+pub trait KeyshareStorage: Send {
+    /// Loads the most recent root keyshare data. Returns an error if the data
+    /// cannot be read. Returns Ok(None) if the data does not exist (i.e. we've
+    /// never participated successfully in a key generation).
+    async fn load(&self) -> anyhow::Result<Option<RootKeyshareData>>;
+
+    /// Stores the most recent root keyshare data. This can only succeed if the
+    /// keyshare didn't exist before or if the new data has a higher epoch.
+    async fn store(&self, data: &RootKeyshareData) -> anyhow::Result<()>;
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -11,6 +11,7 @@ mod db;
 mod hkdf;
 mod indexer;
 mod key_generation;
+mod keyshare;
 mod metrics;
 mod mpc_client;
 mod network;

--- a/node/src/mpc_client.rs
+++ b/node/src/mpc_client.rs
@@ -17,7 +17,7 @@ use crate::triple::{
     SUPPORTED_TRIPLE_GENERATION_BATCH_SIZE,
 };
 
-use crate::key_generation::RootKeyshareData;
+use crate::keyshare::RootKeyshareData;
 use cait_sith::FullSignature;
 use k256::{AffinePoint, Secp256k1};
 use std::sync::Arc;

--- a/node/src/tests/basic_cluster.rs
+++ b/node/src/tests/basic_cluster.rs
@@ -1,4 +1,4 @@
-use crate::cli::Cli;
+use crate::cli::{Cli, StartCmd};
 use crate::config::load_config_file;
 use crate::tests::free_resources_after_shutdown;
 use crate::tracking::AutoAbortTask;
@@ -65,7 +65,7 @@ async fn test_basic_cluster() {
     let normal_runs = (0..NUM_PARTICIPANTS)
         .map(|i| {
             let home_dir = temp_dir.path().join(format!("{}", i));
-            let cli = Cli::Start {
+            let cli = Cli::Start(StartCmd {
                 home_dir: home_dir.to_str().unwrap().to_string(),
                 secret_store_key_hex: hex::encode(encryption_keys[i]),
                 p2p_private_key: std::fs::read_to_string(home_dir.join("p2p_key"))
@@ -73,8 +73,9 @@ async fn test_basic_cluster() {
                     .parse()
                     .unwrap(),
                 account_secret_key: None,
-                root_keyshare: None,
-            };
+                gcp_keyshare_secret_id: None,
+                gcp_project_id: None,
+            });
             AutoAbortTask::from(tokio::spawn(cli.run()))
         })
         .collect::<Vec<_>>();

--- a/node/src/tests/faulty.rs
+++ b/node/src/tests/faulty.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::cli::Cli;
+use crate::cli::{Cli, StartCmd};
 use crate::config::load_config_file;
 use crate::tests::free_resources_after_shutdown;
 use crate::tracking::AutoAbortTask;
@@ -89,7 +89,7 @@ async fn test_faulty_cluster() {
     let mut normal_runs = (0..NUM_PARTICIPANTS)
         .map(|i| {
             let home_dir = temp_dir.path().join(format!("{}", i));
-            let cli = Cli::Start {
+            let cli = Cli::Start(StartCmd {
                 home_dir: home_dir.to_str().unwrap().to_string(),
                 secret_store_key_hex: hex::encode(encryption_keys[i]),
                 p2p_private_key: std::fs::read_to_string(home_dir.join("p2p_key"))
@@ -97,8 +97,9 @@ async fn test_faulty_cluster() {
                     .parse()
                     .unwrap(),
                 account_secret_key: None,
-                root_keyshare: None,
-            };
+                gcp_keyshare_secret_id: None,
+                gcp_project_id: None,
+            });
             (i, AutoAbortTask::from(tokio::spawn(cli.run())))
         })
         .collect::<HashMap<_, _>>();
@@ -228,7 +229,7 @@ async fn test_faulty_cluster() {
 
     let handle = {
         let home_dir = temp_dir.path().join(format!("{}", another_index));
-        let cli = Cli::Start {
+        let cli = Cli::Start(StartCmd {
             home_dir: home_dir.to_str().unwrap().to_string(),
             secret_store_key_hex: hex::encode(encryption_keys[another_index]),
             p2p_private_key: std::fs::read_to_string(home_dir.join("p2p_key"))
@@ -236,8 +237,9 @@ async fn test_faulty_cluster() {
                 .parse()
                 .unwrap(),
             account_secret_key: None,
-            root_keyshare: None,
-        };
+            gcp_keyshare_secret_id: None,
+            gcp_project_id: None,
+        });
         AutoAbortTask::from(tokio::spawn(cli.run()))
     };
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;


### PR DESCRIPTION
This introduces KeyshareStorage interface, with two implementations, one for local encrypted on disk, one for gcp.

They are written in a way that supports keygen and resharing. In the next PR or two, I'll be making keygen and resharing automatic, and the new key would be written via this interface. For now, keygen is still a separate command and resharing is not implemented.

We use the gcp-cloud client library which seems much better maintained than the google-secretmanager1 library used by the old MPC and has a much better interface.