### PR TITLE
Option to Initialize near config

### DIFF
--- a/deployment/gcp-start.sh
+++ b/deployment/gcp-start.sh
@@ -24,7 +24,7 @@ config['state_sync']['sync']['ExternalStorage']['external_storage_fallback_thres
 # Track whichever shard the contract account is on.
 config['tracked_shards'] = []
 config['tracked_accounts'] = ["$MPC_CONTRACT_ID"]
-json.dump(config, open('/data/config.json', 'w'), indent=2)
+json.dump(config, open("$NEAR_NODE_CONFIG_FILE", 'w'), indent=2)
 EOF
 }
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -48,7 +48,7 @@ pub struct InitConfigArgs {
     #[arg(long)]
     pub test_seed: Option<String>,
     /// Number of shards to initialize the chain with
-    #[arg(long)]
+    #[arg(long, default_value = "1")]
     pub num_shards: u64,
     /// Makes block production fast (TESTING ONLY)
     #[arg(long)]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -41,18 +41,6 @@ pub struct InitConfigArgs {
     /// chain/network id (localnet, testnet, devnet, betanet)
     #[arg(long)]
     pub chain_id: Option<String>,
-    /// Account ID for the validator key
-    #[arg(long)]
-    pub account_id: Option<String>,
-    /// Specify private key generated from seed (TESTING ONLY)
-    #[arg(long)]
-    pub test_seed: Option<String>,
-    /// Number of shards to initialize the chain with
-    #[arg(long, default_value = "1")]
-    pub num_shards: u64,
-    /// Makes block production fast (TESTING ONLY)
-    #[arg(long)]
-    pub fast: bool,
     /// Genesis file to use when initialize testnet (including downloading)
     #[arg(long)]
     pub genesis: Option<String>,
@@ -69,14 +57,6 @@ pub struct InitConfigArgs {
     pub download_genesis_url: Option<String>,
     #[arg(long)]
     pub donwload_genesis_records_url: Option<String>,
-    /// Customize max_gas_burnt_view runtime limit.  If not specified, value
-    /// from genesis configuration will be taken.
-    #[arg(long)]
-    pub max_gas_burnt_view: Option<u64>,
-    /// Initialize boots nodes in <node_key>@<ip_addr> format seperated by commas
-    /// to bootstrap the network and store them in config.json
-    #[arg(long)]
-    pub boot_nodes: Option<String>,
 }
 
 #[derive(Parser, Debug)]
@@ -173,13 +153,10 @@ impl Cli {
             Cli::Init(config) => near_indexer::init_configs(
                 &config.dir,
                 config.chain_id,
-                config.account_id.map(|account_id_string| {
-                    near_indexer::near_primitives::types::AccountId::try_from(account_id_string)
-                        .expect("Received accound_id is not valid")
-                }),
-                config.test_seed.as_ref().map(AsRef::as_ref),
-                config.num_shards,
-                config.fast,
+                None,
+                None,
+                1,
+                false,
                 config.genesis.as_ref().map(AsRef::as_ref),
                 config.download_genesis,
                 config.download_genesis_url.as_ref().map(AsRef::as_ref),
@@ -187,14 +164,10 @@ impl Cli {
                     .donwload_genesis_records_url
                     .as_ref()
                     .map(AsRef::as_ref),
-                if config.download_config {
-                    Some(near_config_utils::DownloadConfigType::RPC)
-                } else {
-                    None
-                },
+                Some(near_config_utils::DownloadConfigType::RPC),
                 config.download_config_url.as_ref().map(AsRef::as_ref),
-                config.boot_nodes.as_ref().map(AsRef::as_ref),
-                config.max_gas_burnt_view,
+                None,
+                None,
             ),
             Cli::GenerateTestConfigs {
                 output_dir,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 pub enum Cli {
     Start(StartCmd),
-    /// Generates required file for Near node to run
+    /// Generates/downloads required files for Near node to run
     Init(InitConfigArgs),
     /// Generates a set of test configurations suitable for running MPC in
     /// an integration test.


### PR DESCRIPTION
Allows mpc-node generation of configs required for running near indexer.
```
➜  debug git:(initialize-near-config)  ./mpc-node init --dir near_init  --chain-id mainnet  --download-genesis
➜  debug git:(initialize-near-config)  ls near_init
total 648
drwxr-xr-x@  5 andrei  staff   160B 30 Jan 18:39 .
drwxr-xr-x  11 andrei  staff   352B 30 Jan 18:18 ..
-rw-r--r--@  1 andrei  staff   7.5K 30 Jan 18:39 config.json
-rw-r--r--@  1 andrei  staff   311K 30 Jan 18:39 genesis.json
-rw-------@  1 andrei  staff   214B 30 Jan 18:39 node_key.json
```