### PR TITLE
Chore: additional docker tag

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -51,4 +51,4 @@ jobs:
           file: deployment/Dockerfile-gcp
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: nearone/mpc-node-gcp:latest,nearone/mpc-node-gcp:${{ github.event.inputs.build-ref }}-${{ env.sha_short }}
+          tags: nearone/mpc-node-gcp:latest,nearone/mpc-node-gcp:${{ github.event.inputs.build-ref }},nearone/mpc-node-gcp:${{ github.event.inputs.build-ref }}-${{ env.sha_short }}


### PR DESCRIPTION
Constant mainnet and testnet image tags will allow automatic docker images updates for MPC nodes (with watchtower).
Now every published image will have 3 tags:
latest
brach/tag ref
brach/tag ref + commit hash