### PR TITLE
Check message channel for receive errors

### DIFF
--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -157,3 +157,12 @@ lazy_static! {
         )
         .unwrap();
 }
+
+lazy_static! {
+    pub static ref SIGN_REQUEST_CHANNEL_FAILED: prometheus::IntCounter =
+        prometheus::register_int_counter!(
+            "sign_request_channel_failed",
+            "failed to send on channel in sign_request_channel",
+        )
+        .unwrap();
+}

--- a/node/src/sign_request.rs
+++ b/node/src/sign_request.rs
@@ -72,7 +72,7 @@ impl SignRequestStorage {
                 }
             };
             if added_id == id {
-              break;
+                break;
             }
         }
         let request_ser = self.db.get(DBCol::SignRequest, &key)?.unwrap();


### PR DESCRIPTION
Check if the SignRequestStorage message channel receives an error. This can occur when the number of messages in the channel overflows the capacity. If an error is encounter then the metric SIGN_REQUEST_CHANNEL_FAILED is incremented.