### PR TITLE
reorganize code for sending near transactions

### DIFF
--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -4,9 +4,7 @@ use crate::indexer::handler::ChainSignatureRequest;
 use crate::indexer::participants::{
     ContractInitializingState, ContractResharingState, ContractRunningState, ContractState,
 };
-use crate::indexer::response::{
-    ChainSendTransactionRequest, ChainVotePkArgs, ChainVoteResharedArgs,
-};
+use crate::indexer::types::{ChainSendTransactionRequest, ChainVotePkArgs, ChainVoteResharedArgs};
 use crate::indexer::IndexerAPI;
 use crate::key_generation::{affine_point_to_public_key, run_key_generation_client};
 use crate::key_resharing::run_key_resharing_client;

--- a/node/src/indexer/fake.rs
+++ b/node/src/indexer/fake.rs
@@ -2,7 +2,7 @@ use super::handler::ChainSignatureRequest;
 use super::participants::{
     ContractInitializingState, ContractResharingState, ContractRunningState, ContractState,
 };
-use super::response::{ChainRespondArgs, ChainSendTransactionRequest};
+use super::types::{ChainRespondArgs, ChainSendTransactionRequest};
 use super::IndexerAPI;
 use crate::config::ParticipantsConfig;
 use crate::tracking::{AutoAbortTask, AutoAbortTaskCollection};

--- a/node/src/indexer/mod.rs
+++ b/node/src/indexer/mod.rs
@@ -5,18 +5,19 @@ pub mod handler;
 pub mod lib;
 pub mod participants;
 pub mod real;
-pub mod response;
 pub mod stats;
-pub mod transaction;
+pub mod tx_sender;
+pub mod tx_signer;
+pub mod types;
 
 use handler::ChainSignatureRequest;
 use near_indexer_primitives::types::AccountId;
 use near_indexer_primitives::types::Nonce;
 use participants::ContractState;
-use response::ChainSendTransactionRequest;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, watch};
+use types::ChainSendTransactionRequest;
 
 const RECENT_NONCES_CACHE_SIZE: usize = 10000;
 

--- a/node/src/indexer/real.rs
+++ b/node/src/indexer/real.rs
@@ -1,7 +1,7 @@
 use super::handler::listen_blocks;
 use super::participants::{monitor_chain_state, ContractState};
-use super::response::handle_txn_requests;
 use super::stats::{indexer_logger, IndexerStats};
+use super::tx_sender::handle_txn_requests;
 use super::{IndexerAPI, IndexerState};
 use crate::config::{load_respond_config_file, IndexerConfig};
 use near_crypto::SecretKey;

--- a/node/src/indexer/tx_sender.rs
+++ b/node/src/indexer/tx_sender.rs
@@ -1,0 +1,153 @@
+use super::tx_signer::{TransactionSigner, TransactionSigners};
+use super::ChainSendTransactionRequest;
+use super::IndexerState;
+use super::Nonce;
+use crate::config::RespondConfigFile;
+use crate::metrics;
+use near_crypto::SecretKey;
+use near_indexer_primitives::types::{BlockReference, Finality};
+use near_o11y::WithSpanContextExt;
+use near_sdk::AccountId;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::time;
+
+/// Creates, signs, and submits a function call with the given method and serialized arguments.
+async fn submit_tx(
+    tx_signer: Arc<TransactionSigner>,
+    indexer_state: Arc<IndexerState>,
+    method: String,
+    params_ser: String,
+) -> Option<Nonce> {
+    let Ok(Ok(block)) = indexer_state
+        .view_client
+        .send(near_client::GetBlock(BlockReference::Finality(Finality::Final)).with_span_context())
+        .await
+    else {
+        tracing::warn!(target = "mpc", "failed to get block hash to send tx");
+        return None;
+    };
+
+    let transaction = tx_signer.create_and_sign_function_call_tx(
+        indexer_state.mpc_contract_id.clone(),
+        method,
+        params_ser.into(),
+        block.header.hash,
+        block.header.height,
+    );
+
+    let nonce = transaction.transaction.nonce();
+    tracing::info!(
+        target = "mpc",
+        "sending tx {:?}with ak={} nonce={}",
+        transaction.get_hash(),
+        tx_signer.public_key(),
+        nonce,
+    );
+
+    let result = indexer_state
+        .client
+        .send(
+            near_client::ProcessTxRequest {
+                transaction,
+                is_forwarded: false,
+                check_only: false,
+            }
+            .with_span_context(),
+        )
+        .await;
+    // TODO(#43): Fix the metrics: we no longer send only signature response transactions now.
+    match result {
+        Ok(response) => match response {
+            // We're not a validator, so we should always be routing the transaction.
+            near_client::ProcessTxResponse::RequestRouted => {
+                metrics::MPC_NUM_SIGN_RESPONSES_SENT.inc();
+                Some(nonce)
+            }
+            _ => {
+                metrics::MPC_NUM_SIGN_RESPONSES_FAILED_TO_SEND_IMMEDIATELY.inc();
+                tracing::error!(
+                    target: "mpc",
+                    "Failed to send response tx: unexpected ProcessTxResponse: {:?}",
+                    response
+                );
+                None
+            }
+        },
+        Err(err) => {
+            metrics::MPC_NUM_SIGN_RESPONSES_FAILED_TO_SEND_IMMEDIATELY.inc();
+            tracing::error!(target: "mpc", "Failed to send response tx: {:?}", err);
+            None
+        }
+    }
+}
+
+/// Attempts to ensure that a function call with given method and args is included on-chain.
+/// If the submitted transaction is not observed by the indexer before the `timeout`, tries again.
+/// Will make up to `num_attempts` attempts.
+async fn ensure_send_transaction(
+    tx_signer: Arc<TransactionSigner>,
+    indexer_state: Arc<IndexerState>,
+    method: String,
+    params_ser: String,
+    timeout: Duration,
+    num_attempts: NonZeroUsize,
+) {
+    for _ in 0..num_attempts.into() {
+        let Some(nonce) = submit_tx(
+            tx_signer.clone(),
+            indexer_state.clone(),
+            method.clone(),
+            params_ser.clone(),
+        )
+        .await
+        else {
+            // If the response fails to send immediately, wait a short period and try again
+            time::sleep(Duration::from_secs(1)).await;
+            continue;
+        };
+
+        // If the transaction is sent, wait the full timeout then check if it got included
+        time::sleep(timeout).await;
+        if indexer_state.has_nonce(nonce) {
+            metrics::MPC_NUM_SIGN_RESPONSES_INDEXED.inc();
+            return;
+        }
+        metrics::MPC_NUM_SIGN_RESPONSES_TIMED_OUT.inc();
+    }
+}
+
+pub(crate) async fn handle_txn_requests(
+    mut receiver: mpsc::Receiver<ChainSendTransactionRequest>,
+    owner_account_id: AccountId,
+    owner_secret_key: SecretKey,
+    config: RespondConfigFile,
+    indexer_state: Arc<IndexerState>,
+) {
+    let mut signers = TransactionSigners::new(config, owner_account_id, owner_secret_key)
+        .expect("Failed to initialize transaction signers");
+
+    while let Some(tx_request) = receiver.recv().await {
+        let tx_signer = signers.signer_for(&tx_request);
+        let indexer_state = indexer_state.clone();
+        actix::spawn(async move {
+            let Ok(txn_json) = serde_json::to_string(&tx_request) else {
+                tracing::error!(target: "mpc", "Failed to serialize response args");
+                return;
+            };
+            tracing::debug!(target = "mpc", "tx args {:?}", txn_json);
+            ensure_send_transaction(
+                tx_signer.clone(),
+                indexer_state.clone(),
+                tx_request.method().to_string(),
+                txn_json,
+                Duration::from_secs(10),
+                // TODO(#153): until nonce detection is fixed, this *must* be 1
+                NonZeroUsize::new(1).unwrap(),
+            )
+            .await;
+        });
+    }
+}

--- a/node/src/indexer/types.rs
+++ b/node/src/indexer/types.rs
@@ -1,8 +1,3 @@
-use crate::config::RespondConfigFile;
-use crate::indexer::transaction::TransactionSigner;
-use crate::indexer::IndexerState;
-use crate::indexer::Nonce;
-use crate::metrics;
 use crate::sign_request::SignatureRequest;
 use anyhow::Context;
 use cait_sith::FullSignature;
@@ -12,16 +7,8 @@ use k256::{
     AffinePoint, Scalar, Secp256k1,
 };
 use mpc_contract::primitives;
-use near_crypto::{PublicKey, SecretKey};
-use near_indexer_primitives::types::{BlockReference, Finality};
-use near_o11y::WithSpanContextExt;
-use near_sdk::AccountId;
+use near_crypto::PublicKey;
 use serde::Serialize;
-use std::num::NonZeroUsize;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::sync::mpsc;
-use tokio::time;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Clone, Copy)]
 pub struct SerializableScalar {
@@ -217,208 +204,10 @@ impl ChainRespondArgs {
     }
 }
 
-struct TransactionSigners {
-    /// Signers that we cycle through for responding to signature requests.
-    /// These can correspond to arbitrary near accounts.
-    respond_signers: Vec<Arc<TransactionSigner>>,
-    /// Signer we use for signing vote_pk, vote_reshared, etc., which must
-    /// correspond to the account that this node runs under.
-    owner_signer: Arc<TransactionSigner>,
-    /// next respond signer to use.
-    next_id: usize,
-}
-
-impl TransactionSigners {
-    pub fn new(
-        respond_config: RespondConfigFile,
-        owner_account_id: AccountId,
-        owner_secret_key: SecretKey,
-    ) -> anyhow::Result<Self> {
-        let respond_signers = respond_config
-            .access_keys
-            .iter()
-            .map(|key| {
-                Arc::new(TransactionSigner::from_key(
-                    respond_config.account_id.clone(),
-                    key.clone(),
-                ))
-            })
-            .collect::<Vec<_>>();
-        let owner_signer = Arc::new(TransactionSigner::from_key(
-            owner_account_id,
-            owner_secret_key,
-        ));
-        anyhow::ensure!(
-            !respond_signers.is_empty(),
-            "At least one responding access key must be provided",
-        );
-        Ok(TransactionSigners {
-            respond_signers,
-            owner_signer,
-            next_id: 0,
-        })
-    }
-
-    fn next_respond_signer(&mut self) -> Arc<TransactionSigner> {
-        let signer = self.respond_signers[self.next_id].clone();
-        self.next_id = (self.next_id + 1) % self.respond_signers.len();
-        signer
-    }
-
-    fn owner_signer(&self) -> Arc<TransactionSigner> {
-        self.owner_signer.clone()
-    }
-
-    pub fn signer_for(&mut self, req: &ChainSendTransactionRequest) -> Arc<TransactionSigner> {
-        match req {
-            ChainSendTransactionRequest::Respond(_) => self.next_respond_signer(),
-            _ => self.owner_signer(),
-        }
-    }
-}
-
-/// Creates, signs, and submits a function call with the given method and serialized arguments.
-async fn submit_tx(
-    tx_signer: Arc<TransactionSigner>,
-    indexer_state: Arc<IndexerState>,
-    method: String,
-    params_ser: String,
-) -> Option<Nonce> {
-    let Ok(Ok(block)) = indexer_state
-        .view_client
-        .send(near_client::GetBlock(BlockReference::Finality(Finality::Final)).with_span_context())
-        .await
-    else {
-        tracing::warn!(target = "mpc", "failed to get block hash to send tx");
-        return None;
-    };
-
-    let transaction = tx_signer.create_and_sign_function_call_tx(
-        indexer_state.mpc_contract_id.clone(),
-        method,
-        params_ser.into(),
-        block.header.hash,
-        block.header.height,
-    );
-
-    let nonce = transaction.transaction.nonce();
-    tracing::info!(
-        target = "mpc",
-        "sending tx {:?}with ak={} nonce={}",
-        transaction.get_hash(),
-        tx_signer.public_key(),
-        nonce,
-    );
-
-    let result = indexer_state
-        .client
-        .send(
-            near_client::ProcessTxRequest {
-                transaction,
-                is_forwarded: false,
-                check_only: false,
-            }
-            .with_span_context(),
-        )
-        .await;
-    // TODO(#43): Fix the metrics: we no longer send only signature response transactions now.
-    match result {
-        Ok(response) => match response {
-            // We're not a validator, so we should always be routing the transaction.
-            near_client::ProcessTxResponse::RequestRouted => {
-                metrics::MPC_NUM_SIGN_RESPONSES_SENT.inc();
-                Some(nonce)
-            }
-            _ => {
-                metrics::MPC_NUM_SIGN_RESPONSES_FAILED_TO_SEND_IMMEDIATELY.inc();
-                tracing::error!(
-                    target: "mpc",
-                    "Failed to send response tx: unexpected ProcessTxResponse: {:?}",
-                    response
-                );
-                None
-            }
-        },
-        Err(err) => {
-            metrics::MPC_NUM_SIGN_RESPONSES_FAILED_TO_SEND_IMMEDIATELY.inc();
-            tracing::error!(target: "mpc", "Failed to send response tx: {:?}", err);
-            None
-        }
-    }
-}
-
-/// Attempts to ensure that a function call with given method and args is included on-chain.
-/// If the submitted transaction is not observed by the indexer before the `timeout`, tries again.
-/// Will make up to `num_attempts` attempts.
-async fn ensure_send_transaction(
-    tx_signer: Arc<TransactionSigner>,
-    indexer_state: Arc<IndexerState>,
-    method: String,
-    params_ser: String,
-    timeout: Duration,
-    num_attempts: NonZeroUsize,
-) {
-    for _ in 0..num_attempts.into() {
-        let Some(nonce) = submit_tx(
-            tx_signer.clone(),
-            indexer_state.clone(),
-            method.clone(),
-            params_ser.clone(),
-        )
-        .await
-        else {
-            // If the response fails to send immediately, wait a short period and try again
-            time::sleep(Duration::from_secs(1)).await;
-            continue;
-        };
-
-        // If the transaction is sent, wait the full timeout then check if it got included
-        time::sleep(timeout).await;
-        if indexer_state.has_nonce(nonce) {
-            metrics::MPC_NUM_SIGN_RESPONSES_INDEXED.inc();
-            return;
-        }
-        metrics::MPC_NUM_SIGN_RESPONSES_TIMED_OUT.inc();
-    }
-}
-
-pub(crate) async fn handle_txn_requests(
-    mut receiver: mpsc::Receiver<ChainSendTransactionRequest>,
-    owner_account_id: AccountId,
-    owner_secret_key: SecretKey,
-    config: RespondConfigFile,
-    indexer_state: Arc<IndexerState>,
-) {
-    let mut signers = TransactionSigners::new(config, owner_account_id, owner_secret_key)
-        .expect("Failed to initialize transaction signers");
-
-    while let Some(tx_request) = receiver.recv().await {
-        let tx_signer = signers.signer_for(&tx_request);
-        let indexer_state = indexer_state.clone();
-        actix::spawn(async move {
-            let Ok(txn_json) = serde_json::to_string(&tx_request) else {
-                tracing::error!(target: "mpc", "Failed to serialize response args");
-                return;
-            };
-            tracing::debug!(target = "mpc", "tx args {:?}", txn_json);
-            ensure_send_transaction(
-                tx_signer.clone(),
-                indexer_state.clone(),
-                tx_request.method().to_string(),
-                txn_json,
-                Duration::from_secs(10),
-                // TODO(#153): until nonce detection is fixed, this *must* be 1
-                NonZeroUsize::new(1).unwrap(),
-            )
-            .await;
-        });
-    }
-}
-
 #[cfg(test)]
 mod recovery_id_tests {
     use crate::hkdf::ScalarExt;
-    use crate::indexer::response::ChainRespondArgs;
+    use crate::indexer::types::ChainRespondArgs;
     use cait_sith::FullSignature;
     use k256::ecdsa::{RecoveryId, SigningKey};
     use k256::elliptic_curve::{

--- a/node/src/mpc_client.rs
+++ b/node/src/mpc_client.rs
@@ -1,6 +1,6 @@
 use crate::hkdf::derive_tweak;
 use crate::indexer::handler::ChainSignatureRequest;
-use crate::indexer::response::{ChainRespondArgs, ChainSendTransactionRequest};
+use crate::indexer::types::{ChainRespondArgs, ChainSendTransactionRequest};
 use crate::metrics;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::{MpcTaskId, PresignOutputWithParticipants};


### PR DESCRIPTION
This is a pure refactor in preparation for other changes.

The file `node/src/indexer/response.rs` had grown to contain a bunch of different things. Now that we send more types of outgoing transactions than just `respond` calls, it makes sense to reorganize and rename things a little.