### PR TITLE
Run Near Core in release

### DIFF
--- a/pytest/config.json
+++ b/pytest/config.json
@@ -1,0 +1,6 @@
+{
+  "local": "True",
+  "near_root": "../libs/nearcore/target/release",
+  "binary_name": "neard",
+  "release": "False"
+}

--- a/pytest/exec_pytest.sh
+++ b/pytest/exec_pytest.sh
@@ -104,7 +104,7 @@ if [ $RESET_SUBMODULES == true ]; then
 fi
 
 printf "\nBuilding nearcore"
-if ! log_output bash -c "cd '$LIB_DIR/nearcore' && cargo build --quiet --color=always -p neard"; then
+if ! log_output bash -c "cd '$LIB_DIR/nearcore' && cargo build --quiet --color=always -p neard --release"; then
     echo "Cargo failed to complete nearcore compilation"
     exit 1
 fi
@@ -165,6 +165,10 @@ if $VERBOSE; then
     PYTEST_FLAGS="-s"
     printf "\nVerbose mode activated. Adding -s flag to pytest.\n"
 fi
+
+# set the NEAR config ensuring that the release version of nearcore is run.
+export NEAR_PYTEST_CONFIG="config.json"
+
 if ! log_output pytest $PYTEST_FLAGS; then
     printf '\nError: one or more tests failed. Check output.log for details.\n'
     exit 1

--- a/pytest/readme.md
+++ b/pytest/readme.md
@@ -13,7 +13,7 @@ git submodule update --init --recursive --force
 2. Build nearcore and main node:
 ```bash
 # build nearcore:
-cd libs/nearcore && cargo build -p neard
+cd libs/nearcore && cargo build -p neard --release
 
 # build the contract:
 cd ../chain-signatures && cargo build -p mpc-contract --target=wasm32-unknown-unknown --release
@@ -37,6 +37,7 @@ pip install -r requirements.txt
 
 4. Run pytest:
 ```bash
+export NEAR_PYTEST_CONFIG="config.json"
 pytest # -v -s optional flags for verbosity
 ```
 


### PR DESCRIPTION
We see occasional timeouts during contract creation in the GitHub tests and I was seeing timeouts approximately in 1 in 5 runs on my mac. In exec_pytest.sh we are building the MPC code in release and linking it to a debug build of near core.

This change makes sure that we build and use the release version of near core when running the python tests.

After this change I have not observed timeouts in contract creation.