### PR TITLE
retry "respond" if contract state still has pending request

### DIFF
--- a/node/src/indexer/handler.rs
+++ b/node/src/indexer/handler.rs
@@ -1,9 +1,7 @@
 use crate::hkdf::ScalarExt;
 use crate::indexer::stats::IndexerStats;
-use crate::indexer::IndexerState;
 use crate::metrics;
 use k256::Scalar;
-use near_crypto::PublicKey;
 use near_indexer_primitives::types::AccountId;
 use near_indexer_primitives::views::{
     ActionView, ExecutionOutcomeWithIdView, ExecutionStatusView, ReceiptEnumView, ReceiptView,
@@ -49,9 +47,7 @@ pub(crate) async fn listen_blocks(
     concurrency: std::num::NonZeroU16,
     stats: Arc<Mutex<IndexerStats>>,
     mpc_contract_id: AccountId,
-    account_public_key: Option<PublicKey>,
     sign_request_sender: mpsc::UnboundedSender<ChainSignatureRequest>,
-    indexer_state: Arc<IndexerState>,
 ) {
     let mut handle_messages = tokio_stream::wrappers::ReceiverStream::new(stream)
         .map(|streamer_message| {
@@ -59,9 +55,7 @@ pub(crate) async fn listen_blocks(
                 streamer_message,
                 Arc::clone(&stats),
                 &mpc_contract_id,
-                &account_public_key,
                 sign_request_sender.clone(),
-                indexer_state.clone(),
             )
         })
         .buffer_unordered(usize::from(concurrency.get()));
@@ -73,9 +67,7 @@ async fn handle_message(
     streamer_message: near_indexer_primitives::StreamerMessage,
     stats: Arc<Mutex<IndexerStats>>,
     mpc_contract_id: &AccountId,
-    _account_public_key: &Option<PublicKey>,
     sign_request_sender: mpsc::UnboundedSender<ChainSignatureRequest>,
-    _indexer_state: Arc<IndexerState>,
 ) -> anyhow::Result<()> {
     let block_height = streamer_message.block.header.height;
     let mut stats_lock = stats.lock().await;

--- a/node/src/indexer/real.rs
+++ b/node/src/indexer/real.rs
@@ -60,9 +60,7 @@ pub fn spawn_real_indexer(
                 indexer_config.concurrency,
                 Arc::clone(&stats),
                 indexer_config.mpc_contract_id,
-                Some(account_secret_key.public_key()),
                 sign_request_sender,
-                indexer_state,
             )
             .await;
         });

--- a/node/src/indexer/tx_sender.rs
+++ b/node/src/indexer/tx_sender.rs
@@ -106,7 +106,8 @@ async fn observe_tx_result(
                 .await??;
             match query_response.kind {
                 QueryResponseKind::CallResult(call_result) => {
-                    let pending_request = serde_json::from_slice::<Option<YieldIndex>>(&call_result.result)?;
+                    let pending_request =
+                        serde_json::from_slice::<Option<YieldIndex>>(&call_result.result)?;
                     Ok(if pending_request.is_none() {
                         ChainTransactionState::Executed
                     } else {

--- a/node/src/indexer/tx_sender.rs
+++ b/node/src/indexer/tx_sender.rs
@@ -1,11 +1,15 @@
 use super::tx_signer::{TransactionSigner, TransactionSigners};
+use super::types::ChainGetPendingRequestArgs;
 use super::ChainSendTransactionRequest;
 use super::IndexerState;
-use super::Nonce;
 use crate::config::RespondConfigFile;
 use crate::metrics;
+use mpc_contract::primitives::YieldIndex;
+use near_client::Query;
 use near_crypto::SecretKey;
+use near_indexer_primitives::types::Gas;
 use near_indexer_primitives::types::{BlockReference, Finality};
+use near_indexer_primitives::views::{QueryRequest, QueryResponseKind};
 use near_o11y::WithSpanContextExt;
 use near_sdk::AccountId;
 use std::num::NonZeroUsize;
@@ -20,31 +24,33 @@ async fn submit_tx(
     indexer_state: Arc<IndexerState>,
     method: String,
     params_ser: String,
-) -> Option<Nonce> {
+    gas: Gas,
+) -> bool {
     let Ok(Ok(block)) = indexer_state
         .view_client
         .send(near_client::GetBlock(BlockReference::Finality(Finality::Final)).with_span_context())
         .await
     else {
         tracing::warn!(target = "mpc", "failed to get block hash to send tx");
-        return None;
+        return false;
     };
 
     let transaction = tx_signer.create_and_sign_function_call_tx(
         indexer_state.mpc_contract_id.clone(),
         method,
         params_ser.into(),
+        gas,
         block.header.hash,
         block.header.height,
     );
 
-    let nonce = transaction.transaction.nonce();
+    let tx_hash = transaction.get_hash();
     tracing::info!(
         target = "mpc",
-        "sending tx {:?}with ak={} nonce={}",
-        transaction.get_hash(),
+        "sending tx {:?} with ak={} nonce={}",
+        tx_hash,
         tx_signer.public_key(),
-        nonce,
+        transaction.transaction.nonce(),
     );
 
     let result = indexer_state
@@ -64,7 +70,7 @@ async fn submit_tx(
             // We're not a validator, so we should always be routing the transaction.
             near_client::ProcessTxResponse::RequestRouted => {
                 metrics::MPC_NUM_SIGN_RESPONSES_SENT.inc();
-                Some(nonce)
+                true
             }
             _ => {
                 metrics::MPC_NUM_SIGN_RESPONSES_FAILED_TO_SEND_IMMEDIATELY.inc();
@@ -73,13 +79,65 @@ async fn submit_tx(
                     "Failed to send response tx: unexpected ProcessTxResponse: {:?}",
                     response
                 );
-                None
+                false
             }
         },
         Err(err) => {
             metrics::MPC_NUM_SIGN_RESPONSES_FAILED_TO_SEND_IMMEDIATELY.inc();
             tracing::error!(target: "mpc", "Failed to send response tx: {:?}", err);
-            None
+            false
+        }
+    }
+}
+
+/// Confirms whether the intended effect of the transaction request has been observed on chain.
+/// Used to decide whether to re-submit the transaction.
+async fn confirm_tx_result(
+    indexer_state: Arc<IndexerState>,
+    request: &ChainSendTransactionRequest,
+) -> anyhow::Result<bool> {
+    match request {
+        ChainSendTransactionRequest::Respond(respond_args) => {
+            // Confirm whether the respond call succeeded by checking whether the
+            // pending signature request still exists in the contract state
+            let get_pending_request_args: Vec<u8> =
+                serde_json::to_string(&ChainGetPendingRequestArgs {
+                    request: respond_args.request.clone(),
+                })
+                .unwrap()
+                .into_bytes();
+            let query_response = indexer_state
+                .view_client
+                .send(
+                    Query {
+                        block_reference: BlockReference::Finality(Finality::Final),
+                        request: QueryRequest::CallFunction {
+                            account_id: indexer_state.mpc_contract_id.clone(),
+                            method_name: "get_pending_request".to_string(),
+                            args: get_pending_request_args.into(),
+                        },
+                    }
+                    .with_span_context(),
+                )
+                .await??;
+            match query_response.kind {
+                QueryResponseKind::CallResult(call_result) => {
+                    let result = serde_json::from_slice::<Option<YieldIndex>>(&call_result.result)?;
+                    Ok(result.is_none())
+                }
+                _ => {
+                    anyhow::bail!("Unexpected result from a view client function call");
+                }
+            }
+        }
+        ChainSendTransactionRequest::Join(_) => {
+            anyhow::bail!("not implemented");
+        }
+        ChainSendTransactionRequest::VotePk(_) => {
+            anyhow::bail!("not implemented");
+        }
+        ChainSendTransactionRequest::VoteReshared(_) => {
+            anyhow::bail!("not implemented");
         }
     }
 }
@@ -90,32 +148,43 @@ async fn submit_tx(
 async fn ensure_send_transaction(
     tx_signer: Arc<TransactionSigner>,
     indexer_state: Arc<IndexerState>,
-    method: String,
+    request: ChainSendTransactionRequest,
     params_ser: String,
     timeout: Duration,
     num_attempts: NonZeroUsize,
 ) {
     for _ in 0..num_attempts.into() {
-        let Some(nonce) = submit_tx(
+        if !submit_tx(
             tx_signer.clone(),
             indexer_state.clone(),
-            method.clone(),
+            request.method().to_string(),
             params_ser.clone(),
+            request.gas_required(),
         )
         .await
-        else {
-            // If the response fails to send immediately, wait a short period and try again
+        {
+            // If the transaction fails to send immediately, wait a short period and try again
             time::sleep(Duration::from_secs(1)).await;
             continue;
         };
 
-        // If the transaction is sent, wait the full timeout then check if it got included
+        // Allow time for the transaction to be included
         time::sleep(timeout).await;
-        if indexer_state.has_nonce(nonce) {
-            metrics::MPC_NUM_SIGN_RESPONSES_INDEXED.inc();
-            return;
+        // Then try to check whether it had the intended effect
+        match confirm_tx_result(indexer_state.clone(), &request).await {
+            Ok(true) => {
+                metrics::MPC_NUM_SIGN_RESPONSES_INDEXED.inc();
+                return;
+            }
+            Ok(false) => {
+                metrics::MPC_NUM_SIGN_RESPONSES_TIMED_OUT.inc();
+                continue;
+            }
+            Err(err) => {
+                tracing::warn!(target:"mpc", %err, "encountered error trying to confirm result of transaction {:?}", request);
+                return;
+            }
         }
-        metrics::MPC_NUM_SIGN_RESPONSES_TIMED_OUT.inc();
     }
 }
 
@@ -141,11 +210,10 @@ pub(crate) async fn handle_txn_requests(
             ensure_send_transaction(
                 tx_signer.clone(),
                 indexer_state.clone(),
-                tx_request.method().to_string(),
+                tx_request,
                 txn_json,
                 Duration::from_secs(10),
-                // TODO(#153): until nonce detection is fixed, this *must* be 1
-                NonZeroUsize::new(1).unwrap(),
+                NonZeroUsize::new(3).unwrap(),
             )
             .await;
         });

--- a/node/src/indexer/tx_signer.rs
+++ b/node/src/indexer/tx_signer.rs
@@ -5,7 +5,7 @@ use near_indexer::near_primitives::account::AccessKey;
 use near_indexer_primitives::near_primitives::transaction::{
     FunctionCallAction, SignedTransaction, Transaction, TransactionV0,
 };
-use near_indexer_primitives::types::AccountId;
+use near_indexer_primitives::types::{AccountId, Gas};
 use near_indexer_primitives::CryptoHash;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -37,13 +37,14 @@ impl TransactionSigner {
         receiver_id: AccountId,
         method_name: String,
         args: Vec<u8>,
+        gas: Gas,
         block_hash: CryptoHash,
         block_height: u64,
     ) -> SignedTransaction {
         let action = FunctionCallAction {
             method_name,
             args,
-            gas: 300000000000000,
+            gas,
             deposit: 0,
         };
         let signer_id = match &self.signer {

--- a/node/src/indexer/types.rs
+++ b/node/src/indexer/types.rs
@@ -8,7 +8,10 @@ use k256::{
 };
 use mpc_contract::primitives;
 use near_crypto::PublicKey;
+use near_indexer_primitives::types::Gas;
 use serde::Serialize;
+
+const TGAS: u64 = 1_000_000_000_000;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Clone, Copy)]
 pub struct SerializableScalar {
@@ -89,6 +92,11 @@ pub struct ChainRespondArgs {
 }
 
 #[derive(Serialize, Debug)]
+pub struct ChainGetPendingRequestArgs {
+    pub request: ChainSignatureRequest,
+}
+
+#[derive(Serialize, Debug)]
 pub struct ChainJoinArgs {
     pub url: String,
     pub cipher_pk: primitives::hpke::PublicKey,
@@ -126,6 +134,14 @@ impl ChainSendTransactionRequest {
             ChainSendTransactionRequest::Join(_) => "join",
             ChainSendTransactionRequest::VotePk(_) => "vote_pk",
             ChainSendTransactionRequest::VoteReshared(_) => "vote_reshared",
+        }
+    }
+
+    pub fn gas_required(&self) -> Gas {
+        match self {
+            Self::Respond(_) | Self::Join(_) | Self::VotePk(_) | Self::VoteReshared(_) => {
+                300 * TGAS
+            }
         }
     }
 }

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -92,40 +92,11 @@ lazy_static! {
 }
 
 lazy_static! {
-    pub static ref MPC_NUM_SIGN_RESPONSES_SENT: prometheus::IntCounter =
-        prometheus::register_int_counter!(
-            "mpc_num_signature_responses_sent",
-            "Number of signature responses sent by this node. Note that transactions can still be
-             rejected later when they arrive at the chunk producer, and we wouldn't know of that."
-        )
-        .unwrap();
-}
-
-lazy_static! {
-    pub static ref MPC_NUM_SIGN_RESPONSES_FAILED_TO_SEND_IMMEDIATELY: prometheus::IntCounter =
-        prometheus::register_int_counter!(
-            "mpc_num_signature_responses_failed_to_send_immediately",
-            "Number of signature responses sent by this node, where the sending failed immediately
-             at the local node. Note that transactions can still be rejected later when they arrive
-             at the chunk producer, and we wouldn't know of that."
-        )
-        .unwrap();
-}
-
-lazy_static! {
-    pub static ref MPC_NUM_SIGN_RESPONSES_INDEXED: prometheus::IntCounter =
-        prometheus::register_int_counter!(
-            "mpc_num_sign_responses_indexed",
-            "Number of signature responses sent by this node subsequently observed on chain",
-        )
-        .unwrap();
-}
-
-lazy_static! {
-    pub static ref MPC_NUM_SIGN_RESPONSES_TIMED_OUT: prometheus::IntCounter =
-        prometheus::register_int_counter!(
-            "mpc_num_sign_responses_timed_out",
-            "Number of signature responses sent by this node which did not appear on chain in time",
+    pub static ref MPC_OUTGOING_TRANSACTION_OUTCOMES: prometheus::IntCounterVec =
+        prometheus::register_int_counter_vec!(
+            "mpc_outgoing_transaction_outcomes",
+            "Number of transactions sent by this node, by type and outcome",
+            &["type", "outcome"],
         )
         .unwrap();
 }


### PR DESCRIPTION
In the past we attempted to index `respond` transactions to decide whether they need to be resubmitted. That approach does not work reliably because the account making the respond call may be on a different shard than the signer contract. The node's indexer is configured to track only the shard containing the signer contract.

In this PR, we instead make a view call on `get_pending_request`. It gets executed locally by the node's indexer on the signer contract's state and lets us know whether the respond call has succeeded.

Closes #153.