### PR TITLE
Reimplement connectivity tracking.

### DIFF
--- a/node/src/network/conn.rs
+++ b/node/src/network/conn.rs
@@ -1,0 +1,376 @@
+use crate::primitives::ParticipantId;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Weak};
+
+/// Represents a version of a bidirectional connection with another node.
+/// This allows us to detect if the connection was reset or dropped in either
+/// direction, the lack of which would guarantee that messages are not lost.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ConnectionVersion {
+    pub outgoing: usize,
+    pub incoming: usize,
+}
+
+/// A connection object along with a version number.
+///
+/// The expectation is that every time we make a new connection, the version
+/// would be incremented.
+///
+/// The connection may be dropped, in which case this represents a *pending*
+/// connection of the *next* version. For example, initially the version is 0
+/// and the weak ptr points to nothing. So version() returns 1, meaning that
+/// when to send or receive anything, we would wait until the first connection
+/// is established.
+pub struct ConnectionWithVersion<T: Send + Sync + 'static> {
+    pub connection: Weak<T>,
+    version: usize,
+}
+
+impl<T: Send + Sync + 'static> Clone for ConnectionWithVersion<T> {
+    fn clone(&self) -> Self {
+        Self {
+            connection: self.connection.clone(),
+            version: self.version,
+        }
+    }
+}
+
+impl<T: Send + Sync + 'static> ConnectionWithVersion<T> {
+    pub fn version(&self) -> usize {
+        if self.connection.upgrade().is_some() {
+            self.version
+        } else {
+            self.version + 1
+        }
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.connection.upgrade().is_some()
+    }
+}
+
+/// Struct to track bidirectional connectivity between two nodes.
+/// A node has one NodeConnectivity for each other node in the network.
+pub struct NodeConnectivity<I: Send + Sync + 'static, O: Send + Sync + 'static> {
+    outgoing_sender: tokio::sync::watch::Sender<ConnectionWithVersion<I>>,
+    outgoing_receiver: tokio::sync::watch::Receiver<ConnectionWithVersion<I>>,
+    incoming_sender: tokio::sync::watch::Sender<ConnectionWithVersion<O>>,
+    incoming_receiver: tokio::sync::watch::Receiver<ConnectionWithVersion<O>>,
+    outgoing_version: AtomicUsize,
+    incoming_version: AtomicUsize,
+}
+
+impl<I: Send + Sync + 'static, O: Send + Sync + 'static> NodeConnectivity<I, O> {
+    pub fn new() -> Self {
+        let (outgoing_sender, outgoing_receiver) =
+            tokio::sync::watch::channel(ConnectionWithVersion {
+                connection: Weak::new(),
+                version: 0,
+            });
+        let (incoming_sender, incoming_receiver) =
+            tokio::sync::watch::channel(ConnectionWithVersion {
+                connection: Weak::new(),
+                version: 0,
+            });
+        Self {
+            outgoing_sender,
+            outgoing_receiver,
+            incoming_sender,
+            incoming_receiver,
+            outgoing_version: AtomicUsize::new(0),
+            incoming_version: AtomicUsize::new(0),
+        }
+    }
+
+    /// Sets a new outgoing connection and increments the version by 1.
+    /// The caller needs to drop the connection object when the network
+    /// connection is dropped.
+    pub fn set_outgoing_connection(&self, conn: &Arc<I>) {
+        let version = self.outgoing_version.fetch_add(1, Ordering::Relaxed) + 1;
+        self.outgoing_sender
+            .send(ConnectionWithVersion {
+                connection: Arc::downgrade(conn),
+                version,
+            })
+            .unwrap(); // can't fail: we keep the receiver
+    }
+
+    /// Sets a new incoming connection and increments the version by 1.
+    /// The caller needs to drop the connection object when the network
+    /// connection is dropped.
+    ///
+    /// Unlike outgoing connections, it's possible for multiple incoming
+    /// connections to be active for a given node, as we don't control how
+    /// they make outgoing connections to us. However, for the purpose of
+    /// tracking connectivity and connection resets, we logically assume that
+    /// as soon as this is called, the old connection is considered dropped.
+    pub fn set_incoming_connection(&self, conn: &Arc<O>) {
+        let version = self.incoming_version.fetch_add(1, Ordering::Relaxed) + 1;
+        self.incoming_sender
+            .send(ConnectionWithVersion {
+                connection: Arc::downgrade(conn),
+                version,
+            })
+            .unwrap(); // can't fail: we keep the receiver
+    }
+
+    /// The current ConnectionVersion.
+    pub fn connection_version(&self) -> ConnectionVersion {
+        let outgoing = self.outgoing_receiver.borrow();
+        let incoming = self.incoming_receiver.borrow();
+
+        ConnectionVersion {
+            outgoing: outgoing.version(),
+            incoming: incoming.version(),
+        }
+    }
+
+    pub fn is_bidirectionally_connected(&self) -> bool {
+        let outgoing = self.outgoing_receiver.borrow();
+        let incoming = self.incoming_receiver.borrow();
+        outgoing.is_connected() && incoming.is_connected()
+    }
+
+    /// Given the result of a previous call to `connection_version()`, determine
+    /// if the network connection in either direction may have been interrupted
+    /// since that call. If this returns false, then all messages sent in the
+    /// meantime have been sent on the same connection.
+    pub fn was_connection_interrupted(&self, version: ConnectionVersion) -> bool {
+        let outgoing = self.outgoing_receiver.borrow();
+        let incoming = self.incoming_receiver.borrow();
+        outgoing.version() != version.outgoing || incoming.version() != version.incoming
+    }
+
+    /// Wait for the outgoing connection to be established, if it is not already
+    /// established. If the connection was no longer the expected version,
+    /// returns an error. Otherwise returns the connection object (which may
+    /// be used to send a message).
+    pub async fn wait_for_outgoing_connection(
+        &self,
+        expected: ConnectionVersion,
+    ) -> anyhow::Result<Arc<I>> {
+        let current = self.outgoing_receiver.borrow().clone();
+        let current = if current.version + 1 == expected.outgoing {
+            // If we're waiting for the next version, that means we want to wait for a
+            // new connection to be established.
+            self.outgoing_receiver
+                .clone()
+                .wait_for(|item| item.version >= expected.outgoing)
+                .await?
+                .clone()
+        } else {
+            current
+        };
+        if current.version != expected.outgoing {
+            anyhow::bail!(
+                "Connection was reset (expected version {} but got {})",
+                expected.outgoing,
+                current.version
+            );
+        }
+        let Some(conn) = current.connection.upgrade() else {
+            anyhow::bail!("Connection was dropped");
+        };
+        Ok(conn)
+    }
+}
+
+/// Convenient collection of multiple NodeConnectivity objects.
+pub struct AllNodeConnectivities<I: Send + Sync + 'static, O: Send + Sync + 'static> {
+    my_participant_id: ParticipantId,
+    connectivities: HashMap<ParticipantId, Arc<NodeConnectivity<I, O>>>,
+}
+
+impl<I: Send + Sync + 'static, O: Send + Sync + 'static> AllNodeConnectivities<I, O> {
+    pub fn new(my_participant_id: ParticipantId, all_participant_ids: &[ParticipantId]) -> Self {
+        let mut connectivities = HashMap::new();
+        for p in all_participant_ids {
+            if *p == my_participant_id {
+                continue;
+            }
+            connectivities.insert(*p, Arc::new(NodeConnectivity::new()));
+        }
+        Self {
+            my_participant_id,
+            connectivities,
+        }
+    }
+
+    /// Waits for `threshold` number of connections (a freebie is included for the node itself)
+    /// to be bidirectionally established at the same time.
+    pub async fn wait_for_ready(&self, threshold: usize) {
+        let mut receivers = self
+            .connectivities
+            .values()
+            .map(|c| (c.outgoing_receiver.clone(), c.incoming_receiver.clone()))
+            .collect::<Vec<_>>();
+        loop {
+            let mut connected_count = 0;
+            for (outgoing_receiver, incoming_receiver) in &receivers {
+                let outgoing = outgoing_receiver.borrow();
+                let incoming = incoming_receiver.borrow();
+                if outgoing.is_connected() && incoming.is_connected() {
+                    connected_count += 1;
+                }
+            }
+            if connected_count + 1 >= threshold {
+                break;
+            }
+
+            let update_futs = receivers
+                .iter_mut()
+                .map(|(outgoing_receiver, incoming_receiver)| {
+                    futures::future::select(
+                        Box::pin(outgoing_receiver.changed()),
+                        Box::pin(incoming_receiver.changed()),
+                    )
+                })
+                .collect::<Vec<_>>();
+            futures::future::select_all(update_futs).await;
+        }
+    }
+
+    /// Returns a list of all participant IDs that are bidirectionally connected,
+    /// including the node itself, sorted in ascending order.
+    pub fn all_alive_participant_ids(&self) -> Vec<ParticipantId> {
+        let mut result = Vec::new();
+        for (p, connectivity) in &self.connectivities {
+            if connectivity.is_bidirectionally_connected() {
+                result.push(*p);
+            }
+        }
+        result.push(self.my_participant_id);
+        result.sort();
+        result
+    }
+
+    pub fn get(&self, p: ParticipantId) -> anyhow::Result<Arc<NodeConnectivity<I, O>>> {
+        self.connectivities
+            .get(&p)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("No such participant {}", p))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::async_testing::{run_future_once, MaybeReady};
+    use crate::network::conn::{AllNodeConnectivities, ConnectionVersion, NodeConnectivity};
+    use crate::primitives::ParticipantId;
+    use futures::FutureExt;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_connection_version() {
+        use super::*;
+        let conn = ConnectionWithVersion {
+            connection: Weak::<()>::new(),
+            version: 0,
+        };
+        assert_eq!(conn.version(), 1);
+        assert!(!conn.is_connected());
+
+        let arc = Arc::new(0);
+        let conn = ConnectionWithVersion {
+            connection: Arc::downgrade(&arc),
+            version: 2,
+        };
+        assert_eq!(conn.version(), 2);
+        assert!(conn.is_connected());
+    }
+
+    fn ver(outgoing: usize, incoming: usize) -> ConnectionVersion {
+        ConnectionVersion { outgoing, incoming }
+    }
+
+    #[test]
+    fn test_connectivity() {
+        let connectivity = NodeConnectivity::<usize, usize>::new();
+        assert_eq!(connectivity.connection_version(), ver(1, 1));
+        assert!(!connectivity.is_bidirectionally_connected());
+        assert!(!connectivity.was_connection_interrupted(ver(1, 1)));
+
+        let conn = Arc::new(0);
+        connectivity.set_outgoing_connection(&conn);
+        assert_eq!(connectivity.connection_version(), ver(1, 1));
+        assert!(!connectivity.is_bidirectionally_connected());
+        assert!(!connectivity.was_connection_interrupted(ver(1, 1)));
+
+        let conn2 = Arc::new(0);
+        connectivity.set_incoming_connection(&conn2);
+        assert_eq!(connectivity.connection_version(), ver(1, 1));
+        assert!(connectivity.is_bidirectionally_connected());
+        assert!(!connectivity.was_connection_interrupted(ver(1, 1)));
+
+        drop(conn);
+        assert_eq!(connectivity.connection_version(), ver(2, 1));
+        assert!(!connectivity.is_bidirectionally_connected());
+        assert!(connectivity.was_connection_interrupted(ver(1, 1)));
+        assert!(!connectivity.was_connection_interrupted(ver(2, 1)));
+
+        let conn3 = Arc::new(0);
+        connectivity.set_incoming_connection(&conn3);
+        assert_eq!(connectivity.connection_version(), ver(2, 2));
+        assert!(!connectivity.is_bidirectionally_connected());
+        assert!(connectivity.was_connection_interrupted(ver(2, 1)));
+        assert!(!connectivity.was_connection_interrupted(ver(2, 2)));
+
+        drop(conn2);
+        assert_eq!(connectivity.connection_version(), ver(2, 2));
+
+        let conn4 = Arc::new(0);
+        connectivity.set_outgoing_connection(&conn4);
+        assert_eq!(connectivity.connection_version(), ver(2, 2));
+        assert!(connectivity.is_bidirectionally_connected());
+        assert!(connectivity.was_connection_interrupted(ver(1, 2)));
+        assert!(!connectivity.was_connection_interrupted(ver(2, 2)));
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_ready() {
+        let id0 = ParticipantId::from_raw(1);
+        let id1 = ParticipantId::from_raw(2);
+        let id2 = ParticipantId::from_raw(3);
+        let connectivity = AllNodeConnectivities::<usize, usize>::new(id1, &[id0, id1, id2]);
+        assert_eq!(connectivity.all_alive_participant_ids(), vec![id1]);
+
+        let conn10 = Arc::new(0);
+        let conn01 = Arc::new(0);
+
+        connectivity
+            .get(id0)
+            .unwrap()
+            .set_outgoing_connection(&conn10);
+        connectivity
+            .get(id0)
+            .unwrap()
+            .set_incoming_connection(&conn01);
+
+        assert_eq!(connectivity.wait_for_ready(2).now_or_never(), Some(()));
+        assert_eq!(connectivity.all_alive_participant_ids(), vec![id0, id1]);
+
+        let fut = connectivity.wait_for_ready(3);
+        let MaybeReady::Future(fut) = run_future_once(fut) else {
+            panic!("wait_for_ready(3) should not be ready yet");
+        };
+
+        let conn12 = Arc::new(0);
+        let conn21 = Arc::new(0);
+
+        connectivity
+            .get(id2)
+            .unwrap()
+            .set_outgoing_connection(&conn12);
+        connectivity
+            .get(id2)
+            .unwrap()
+            .set_incoming_connection(&conn21);
+
+        assert_eq!(fut.now_or_never(), Some(()));
+        assert_eq!(
+            connectivity.all_alive_participant_ids(),
+            vec![id0, id1, id2]
+        );
+    }
+}

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -1,5 +1,6 @@
 use crate::config::MpcConfig;
 use crate::metrics;
+use crate::network::conn::{AllNodeConnectivities, ConnectionVersion, NodeConnectivity};
 use crate::network::{MeshNetworkTransportReceiver, MeshNetworkTransportSender};
 use crate::primitives::{MpcMessage, MpcPeerMessage, ParticipantId};
 use crate::tracking::{self, AutoAbortTask, AutoAbortTaskCollection};
@@ -11,12 +12,10 @@ use rustls::server::danger::ClientCertVerifier;
 use rustls::{ClientConfig, CommonState, ServerConfig};
 use std::collections::{HashMap, HashSet};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc::{self, Receiver, UnboundedSender};
-use tokio::task::JoinSet;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::sync::CancellationToken;
 use x509_parser::prelude::{FromDer, X509Certificate};
@@ -28,7 +27,7 @@ pub struct TlsMeshSender {
     my_id: ParticipantId,
     participants: Vec<ParticipantId>,
     connections: HashMap<ParticipantId, Arc<PersistentConnection>>,
-    connectivities: Arc<HashMap<ParticipantId, ConnectivityIndicator>>,
+    connectivities: Arc<AllNodeConnectivities<TlsConnection, ()>>,
 }
 
 /// Implements MeshNetworkTransportReceiver.
@@ -93,12 +92,7 @@ impl ClientCertVerifier for DummyClientCertVerifier {
 /// connection is broken.
 struct PersistentConnection {
     target_participant_id: ParticipantId,
-    // Current connection and version. The connection is an Option because it
-    // can be None if the connection was never established. It is a Weak
-    // because the connection is owned by the loop-to-connect task (see the
-    // `new` method) and when the connection is closed it is dropped. The
-    // version is incremented every time the connection is re-established.
-    current: tokio::sync::watch::Receiver<Option<(usize, Weak<TlsConnection>)>>,
+    connectivity: Arc<NodeConnectivity<TlsConnection, ()>>,
     // The task that loops to connect to the target. When `PersistentConnection`
     // is dropped, this task is aborted. The task owns any active connection,
     // so dropping it also frees any connection currently alive.
@@ -243,48 +237,17 @@ impl PersistentConnection {
     const CONNECTION_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 
     /// Sends a message over the connection. If the connection was reset, fail.
-    async fn send_message(&self, expected_version: usize, msg: Vec<u8>) -> anyhow::Result<()> {
-        let (expected_version, version, conn) = if expected_version == 0 {
-            // This means that the connection was never established when the computation
-            // started. This is possible when someone else initiated the computation,
-            // before we've got a chance to establish an outgoing connection to the
-            // involved participants yet. So in this case, we shall wait for a connection.
-            let current_conn = self.current.borrow().clone();
-            match current_conn {
-                Some((version, conn)) => (1, version, conn),
-                None => {
-                    let (version, conn) = self
-                        .current
-                        .clone()
-                        .wait_for(|conn| conn.is_some())
-                        .await?
-                        .clone()
-                        .unwrap();
-                    (1, version, conn)
-                }
-            }
-        } else {
-            match self.current.borrow().clone() {
-                Some((version, conn)) => (expected_version, version, conn),
-                None => {
-                    anyhow::bail!(
-                        "Programming error: Connection to {} is missing",
-                        self.target_participant_id
-                    );
-                }
-            }
-        };
-
-        if version != expected_version {
-            anyhow::bail!(
-                "Connection to {} is not the original connection expected",
-                self.target_participant_id
-            );
-        }
-        let Some(conn) = conn.upgrade() else {
-            anyhow::bail!("Connection to {} was dropped", self.target_participant_id);
-        };
-        conn.send(msg)?;
+    async fn send_message(
+        &self,
+        expected_version: ConnectionVersion,
+        msg: Vec<u8>,
+    ) -> anyhow::Result<()> {
+        self.connectivity
+            .wait_for_outgoing_connection(expected_version)
+            .await
+            .with_context(|| format!("Cannot send message to {}", self.target_participant_id))?
+            .send(msg)
+            .with_context(|| format!("Cannot send message to {}", self.target_participant_id))?;
         Ok(())
     }
 
@@ -294,14 +257,12 @@ impl PersistentConnection {
         target_address: String,
         target_participant_id: ParticipantId,
         participant_identities: Arc<ParticipantIdentities>,
-        connectivity_indicator: ConnectivityIndicator,
+        connectivity: Arc<NodeConnectivity<TlsConnection, ()>>,
     ) -> anyhow::Result<PersistentConnection> {
-        let (current_sender, current_receiver) = tokio::sync::watch::channel(None);
-
+        let connectivity_clone = connectivity.clone();
         let task = tracking::spawn(
             &format!("Persistent connection to {}", target_participant_id),
             async move {
-                let mut connection_version = 1;
                 loop {
                     let new_conn = match TlsConnection::new(
                         client_config.clone(),
@@ -333,21 +294,14 @@ impl PersistentConnection {
                         }
                     };
                     let new_conn = Arc::new(new_conn);
-                    if current_sender
-                        .send(Some((connection_version, Arc::downgrade(&new_conn))))
-                        .is_err()
-                    {
-                        break;
-                    }
-                    connection_version += 1;
-                    let _indicator_guard = connectivity_indicator.mark_connected_outgoing();
+                    connectivity.set_outgoing_connection(&new_conn);
                     new_conn.wait_for_close().await;
                 }
             },
         );
         Ok(PersistentConnection {
             target_participant_id,
-            current: current_receiver,
+            connectivity: connectivity_clone,
             _task: task,
         })
     }
@@ -450,7 +404,15 @@ pub async fn new_tls_mesh_network(
     // Prepare participant data.
     let mut participant_identities = ParticipantIdentities::default();
     let mut connections = HashMap::new();
-    let mut connectivities = HashMap::new();
+    let connectivities = Arc::new(AllNodeConnectivities::new(
+        config.my_participant_id,
+        &config
+            .participants
+            .participants
+            .iter()
+            .map(|p| p.id)
+            .collect::<Vec<_>>(),
+    ));
     for participant in &config.participants.participants {
         if participant.id == config.my_participant_id {
             continue;
@@ -458,9 +420,7 @@ pub async fn new_tls_mesh_network(
         participant_identities
             .key_to_participant_id
             .insert(participant.p2p_public_key.clone(), participant.id);
-        connectivities.insert(participant.id, ConnectivityIndicator::new());
     }
-    let connectivities = Arc::new(connectivities);
     let participant_identities = Arc::new(participant_identities);
     for participant in &config.participants.participants {
         if participant.id == config.my_participant_id {
@@ -474,7 +434,7 @@ pub async fn new_tls_mesh_network(
                 format!("{}:{}", participant.address, participant.port),
                 participant.id,
                 participant_identities.clone(),
-                connectivities.get(&participant.id).unwrap().clone(),
+                connectivities.get(participant.id)?,
             )?),
         );
     }
@@ -505,10 +465,10 @@ pub async fn new_tls_mesh_network(
                 let peer_id = verify_peer_identity(stream.get_ref().1, &participant_identities)?;
                 tracking::set_progress(&format!("Authenticated as {}", peer_id));
                 tracing::info!("Incoming {} <-- {} connected", my_id, peer_id);
-                let _indicator_guard = connectivities
-                    .get(&peer_id)
-                    .unwrap()
-                    .mark_connected_incoming();
+                let incoming_conn = Arc::new(());
+                connectivities
+                    .get(peer_id)?
+                    .set_incoming_connection(&incoming_conn);
                 let mut received_bytes: u64 = 0;
                 loop {
                     let tag = stream.read_u8().await?;
@@ -601,83 +561,6 @@ fn verify_peer_identity(
     Ok(*peer_id)
 }
 
-/// Struct to track bidirectional connectivity between two nodes.
-/// A node has one ConnectivityIndicator for each other node in the network.
-#[derive(Clone)]
-struct ConnectivityIndicator {
-    /// A packed integer; the high 32 bits represents the number of incoming
-    /// connections currently active from the other node, and the low 32 bits
-    /// represents the number of outgoing connections currently active to the
-    /// other node. The latter is expected to never exceed 1.
-    ///
-    /// By looking at this integer we can determine if both directions are
-    /// connected.
-    connected: Arc<AtomicU64>,
-    /// This is used to implement `wait_for_both_connected` by allowing the
-    /// waiter to asynchronously wait for the atomic to change.
-    notify: Arc<tokio::sync::Notify>,
-}
-
-struct DropToDisconnectOutgoing(ConnectivityIndicator);
-impl Drop for DropToDisconnectOutgoing {
-    fn drop(&mut self) {
-        self.0.connected.fetch_sub(1, Ordering::Relaxed);
-        self.0.notify.notify_waiters();
-    }
-}
-
-struct DropToDisconnectIncoming(ConnectivityIndicator);
-impl Drop for DropToDisconnectIncoming {
-    fn drop(&mut self) {
-        self.0
-            .connected
-            .fetch_sub(ConnectivityIndicator::INCOMING_COUNT, Ordering::Relaxed);
-        self.0.notify.notify_waiters();
-    }
-}
-
-impl ConnectivityIndicator {
-    const INCOMING_COUNT: u64 = 1 << 32;
-
-    fn new() -> Self {
-        Self {
-            connected: Arc::new(AtomicU64::new(0)),
-            notify: Arc::new(tokio::sync::Notify::new()),
-        }
-    }
-
-    fn mark_connected_outgoing(&self) -> DropToDisconnectOutgoing {
-        self.connected.fetch_add(1, Ordering::Relaxed);
-        self.notify.notify_waiters();
-        DropToDisconnectOutgoing(self.clone())
-    }
-
-    fn mark_connected_incoming(&self) -> DropToDisconnectIncoming {
-        self.connected
-            .fetch_add(Self::INCOMING_COUNT, Ordering::Relaxed);
-        self.notify.notify_waiters();
-        DropToDisconnectIncoming(self.clone())
-    }
-
-    fn is_connected_both_ways(&self) -> bool {
-        let flag = self.connected.load(Ordering::Relaxed);
-        flag >= Self::INCOMING_COUNT && flag & (Self::INCOMING_COUNT - 1) >= 1
-    }
-
-    /// Only returns when both directions are connected.
-    /// This should not be used by two tasks concurrently.
-    async fn wait_for_both_connected(&self) {
-        loop {
-            if self.is_connected_both_ways() {
-                return;
-            }
-            // Should not be used concurrently from multiple tasks, because this
-            // notification pattern can miss notifications if there are two waiters.
-            self.notify.notified().await;
-        }
-    }
-}
-
 #[async_trait]
 impl MeshNetworkTransportSender for TlsMeshSender {
     fn my_participant_id(&self) -> ParticipantId {
@@ -688,18 +571,29 @@ impl MeshNetworkTransportSender for TlsMeshSender {
         self.participants.clone()
     }
 
-    fn connection_version(&self, participant_id: ParticipantId) -> usize {
-        self.connections
-            .get(&participant_id)
-            .map(|conn| conn.current.borrow().clone().map(|(v, _)| v).unwrap_or(0))
-            .unwrap_or(0)
+    fn connection_version(&self, participant_id: ParticipantId) -> ConnectionVersion {
+        self.connectivities
+            .get(participant_id)
+            .map(|c| c.connection_version())
+            .unwrap_or_default()
+    }
+
+    fn was_connection_interrupted(
+        &self,
+        participant_id: ParticipantId,
+        version: ConnectionVersion,
+    ) -> bool {
+        self.connectivities
+            .get(participant_id)
+            .map(|c| c.was_connection_interrupted(version))
+            .unwrap_or_default()
     }
 
     async fn send(
         &self,
         recipient_id: ParticipantId,
         message: MpcMessage,
-        connection_version: usize,
+        connection_version: ConnectionVersion,
     ) -> anyhow::Result<()> {
         self.connections
             .get(&recipient_id)
@@ -710,34 +604,12 @@ impl MeshNetworkTransportSender for TlsMeshSender {
     }
 
     async fn wait_for_ready(&self, threshold: usize) -> anyhow::Result<()> {
-        assert!(threshold - 1 <= self.connections.len());
-        let mut join_set = JoinSet::new();
-        for (participant_id, indicator) in &*self.connectivities {
-            let participant_id = *participant_id;
-            let my_id = self.my_id;
-            let indicator = indicator.clone();
-            join_set.spawn(async move {
-                indicator.wait_for_both_connected().await;
-                tracing::info!("Bidrectional {} <--> {} connected", my_id, participant_id);
-                anyhow::Ok(())
-            });
-        }
-        for _ in 1..threshold {
-            join_set.join_next().await.unwrap()??;
-        }
+        self.connectivities.wait_for_ready(threshold).await;
         Ok(())
     }
 
     fn all_alive_participant_ids(&self) -> Vec<ParticipantId> {
-        let mut ids = self
-            .connectivities
-            .iter()
-            .filter(|(_, indicator)| indicator.is_connected_both_ways())
-            .map(|(id, _)| *id)
-            .chain([self.my_id])
-            .collect::<Vec<_>>();
-        ids.sort();
-        ids
+        self.connectivities.all_alive_participant_ids()
     }
 
     fn emit_metrics(&self) {
@@ -934,7 +806,7 @@ mod tests {
                             task_id: crate::primitives::MpcTaskId::KeyGeneration,
                             participants: vec![],
                         },
-                        1,
+                        sender0.connection_version(participant1),
                     )
                     .await
                     .unwrap();
@@ -950,7 +822,7 @@ mod tests {
                             task_id: crate::primitives::MpcTaskId::KeyGeneration,
                             participants: vec![],
                         },
-                        1,
+                        sender1.connection_version(participant0),
                     )
                     .await
                     .unwrap();


### PR DESCRIPTION
All cait-sith computations have no fault tolerance. In order to ensure that messages are not lost during a computation (since a single lost message would make the computation fail), we check if the TCP connections we started the computation with are the same as the TCP connections we currently have.

Previously, this was done in a couple of fragmented ways:
* When sending a message to a participant, we check if the outgoing `PersistentConnection`'s current (connection, version) tuple matches with the version we grabbed when we started the computation. If not, we fail the send (and thus abort the computation).
* When receiving a message, we check if all the participants needed for the computation are still alive, but we only check this once per second.

There are various subtle problems with this fragmented approach; it's hard to list them exhaustively but here are some:
* We're handling outgoing and incoming connections separately. The (connection, version) tuple only tracks outgoing connections. If incoming connections are dropped during a computation, we don't immediately know of it. Yes, we have `all_alive_participant_ids()`, but that is weaker because if an incoming connection is reset, we can miss that.
* If a node receives a computation while an incoming connection to a required participant is still being established, the computation can fail due to the `all_alive_participant_ids` check, even though we could wait for the incoming connection (and we probably should because the leader of the computation saw the participant online.)
* The fragmented state-keeping for outgoing connections may also mean there can be subtle race conditions where the `ConnectivityIndicator` says we're connected but we're actually not, or vice versa.

This PR unifies the handling of outgoing and incoming connection version tracking and connectivity tracking and puts that logic in a separate file `conn.rs`.
* We also implement `wait_for_ready` correctly now: we wait for `threshold` number of parties to **simultaneously** be connected; previously we only waited for connections one at a time, meaning that by the time it returns, some of the earlier awaited nodes may now be disconnected.
* Both sending and receiving code now checks for version mismatch. This should now ensure that any interruption in the network should abort the computation.
* If a computation is received while a participant is not yet connected (either incoming or outgoing), we now wait for the desired connection. I think mostly this is desirable, but I need to revisit this - there are pros and cons of either decision. Ideally, we have an abort mechanism where the leader of the computation can tell everyone to abort - that would solve this problem of distributed decision making, but that's a much larger topic.

This still does not really solve any real reliability problems, but it at least makes this part of the code more consistent and modular.