### PR TITLE
refactor(audit): remove explicit `.into_iter`

### DIFF
--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -110,7 +110,7 @@ pub async fn run_protocol<T>(
             // to send many messages at once to the same recipient.
             // TODO(#21): maybe we can fix the cait-sith protocol to not ask us to send so many
             // messages in the first place.
-            for (p, messages) in messages_to_send.into_iter() {
+            for (p, messages) in messages_to_send {
                 if messages.is_empty() {
                     continue;
                 }


### PR DESCRIPTION
This commit addresses finding no. B7 from the Trail of Bits audit titled _'Explicit `into_iter` loop'_.