### PR TITLE
distinguish missing respond.yaml from a misconfigured one

### DIFF
--- a/pytest/tests/test_without_respond_yaml.py
+++ b/pytest/tests/test_without_respond_yaml.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+Starts an mpc cluster without respond.yaml configs.
+Verifies that signature requests are handled successfully.
+"""
+
+import os
+import sys
+import pathlib
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from common_lib import shared
+from common_lib.contracts import load_mpc_contract
+
+
+@pytest.mark.parametrize("num_requests", [(10)])
+def test_without_respond_yaml(num_requests):
+    cluster = shared.start_cluster_with_mpc(2, 2, 0,
+                                            load_mpc_contract())
+    cluster.init_contract(threshold=2)
+
+    for node in cluster.mpc_nodes:
+        home_dir_fnames = os.listdir(node.home_dir)
+        assert 'config.yaml' in home_dir_fnames
+        assert 'respond.yaml' not in home_dir_fnames
+
+    cluster.send_and_await_signature_requests(num_requests)


### PR DESCRIPTION
This PR follows up #219, in which `respond.yaml` was made optional:

> I'd prefer if load_respond_config_file returned a Result<Option<...>> where if the file doesn't exist it is explicitly returned as an Option::None. The reason is that it can be easy to make a mistake in the yaml syntax and cause the config to fail to deserialize, and yet it would almost silently fall back to single account.

A pytest is also added to verify that nodes can run without `respond.yaml` (previously confirmed only via manual testing).