### PR TITLE
Implement leader-centric computation and indexer height network APIs.

### DIFF
--- a/node/src/key_generation.rs
+++ b/node/src/key_generation.rs
@@ -1,6 +1,6 @@
 use crate::config::MpcConfig;
 use crate::keyshare::{KeyshareStorage, RootKeyshareData};
-use crate::network::computation::{MpcLeaderCentricComputation, MpcLeaderCentricComputationExt};
+use crate::network::computation::MpcLeaderCentricComputation;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::MpcTaskId;
 use crate::protocol::run_protocol;
@@ -105,7 +105,7 @@ pub fn affine_point_to_public_key(point: AffinePoint) -> anyhow::Result<near_cry
 #[cfg(test)]
 mod tests {
     use crate::key_generation::KeyGenerationComputation;
-    use crate::network::computation::MpcLeaderCentricComputationExt;
+    use crate::network::computation::MpcLeaderCentricComputation;
     use crate::network::testing::run_test_clients;
     use crate::network::{MeshNetworkClient, NetworkTaskChannel};
     use crate::primitives::MpcTaskId;

--- a/node/src/key_generation.rs
+++ b/node/src/key_generation.rs
@@ -1,12 +1,12 @@
 use crate::config::MpcConfig;
 use crate::keyshare::{KeyshareStorage, RootKeyshareData};
-use crate::network::{MeshNetworkClient, NetworkTaskChannel, NetworkTaskChannelWrapper};
-use crate::primitives::{MpcTaskId, ParticipantId};
+use crate::network::computation::{MpcLeaderCentricComputation, MpcLeaderCentricComputationExt};
+use crate::network::{MeshNetworkClient, NetworkTaskChannel};
+use crate::primitives::MpcTaskId;
 use crate::protocol::run_protocol;
 use anyhow::Context;
 use cait_sith::protocol::Participant;
 use cait_sith::KeygenOutput;
-use futures::FutureExt;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::{AffinePoint, Secp256k1};
 use std::sync::Arc;
@@ -14,19 +14,30 @@ use tokio::sync::mpsc;
 
 /// Runs the key generation protocol, returning the key generated.
 /// This protocol is identical for the leader and the followers.
-pub async fn run_key_generation(
-    channel: &mut NetworkTaskChannel,
-    me: ParticipantId,
+pub struct KeyGenerationComputation {
     threshold: usize,
-) -> anyhow::Result<KeygenOutput<Secp256k1>> {
-    let cs_participants = channel
-        .participants()
-        .iter()
-        .copied()
-        .map(Participant::from)
-        .collect::<Vec<_>>();
-    let protocol = cait_sith::keygen::<Secp256k1>(&cs_participants, me.into(), threshold)?;
-    run_protocol("key generation", channel, protocol).await
+}
+
+#[async_trait::async_trait]
+impl MpcLeaderCentricComputation<KeygenOutput<Secp256k1>> for KeyGenerationComputation {
+    async fn compute(
+        self,
+        channel: &mut NetworkTaskChannel,
+    ) -> anyhow::Result<KeygenOutput<Secp256k1>> {
+        let cs_participants = channel
+            .participants()
+            .iter()
+            .copied()
+            .map(Participant::from)
+            .collect::<Vec<_>>();
+        let me = channel.my_participant_id();
+        let protocol = cait_sith::keygen::<Secp256k1>(&cs_participants, me.into(), self.threshold)?;
+        run_protocol("key generation", channel, protocol).await
+    }
+
+    fn leader_waits_for_success(&self) -> bool {
+        false
+    }
 }
 
 /// Performs the key generation protocol, saving the keyshare to disk.
@@ -37,7 +48,7 @@ pub async fn run_key_generation_client(
     config: Arc<MpcConfig>,
     client: Arc<MeshNetworkClient>,
     keyshare_storage: Box<dyn KeyshareStorage>,
-    mut channel_receiver: mpsc::UnboundedReceiver<NetworkTaskChannelWrapper>,
+    mut channel_receiver: mpsc::UnboundedReceiver<NetworkTaskChannel>,
 ) -> anyhow::Result<()> {
     if keyshare_storage.load().await?.is_some() {
         anyhow::bail!("Keyshare already exists, refusing to run key generation");
@@ -67,16 +78,15 @@ pub async fn run_key_generation_client(
             break channel;
         }
     };
-    let key = channel
-        .perform_leader_centric_computation(false, move |channel| {
-            run_key_generation(
-                channel,
-                my_participant_id,
-                config.participants.threshold as usize,
-            )
-            .boxed()
-        })
-        .await?;
+    let key = KeyGenerationComputation {
+        threshold: config.participants.threshold as usize,
+    }
+    .perform_leader_centric_computation(
+        channel,
+        // TODO(#195): Move timeout here instead of in Coordinator.
+        std::time::Duration::from_secs(60),
+    )
+    .await?;
     keyshare_storage
         .store(&RootKeyshareData::new(0, key.clone()))
         .await?;
@@ -94,14 +104,14 @@ pub fn affine_point_to_public_key(point: AffinePoint) -> anyhow::Result<near_cry
 
 #[cfg(test)]
 mod tests {
-    use super::run_key_generation;
+    use crate::key_generation::KeyGenerationComputation;
+    use crate::network::computation::MpcLeaderCentricComputationExt;
     use crate::network::testing::run_test_clients;
-    use crate::network::{MeshNetworkClient, NetworkTaskChannelWrapper};
+    use crate::network::{MeshNetworkClient, NetworkTaskChannel};
     use crate::primitives::MpcTaskId;
     use crate::tests::TestGenerators;
     use crate::tracking::testing::start_root_task_with_periodic_dump;
     use cait_sith::KeygenOutput;
-    use futures::FutureExt;
     use k256::Secp256k1;
     use std::sync::Arc;
     use tokio::sync::mpsc;
@@ -122,7 +132,7 @@ mod tests {
 
     async fn run_keygen_client(
         client: Arc<MeshNetworkClient>,
-        mut channel_receiver: mpsc::UnboundedReceiver<NetworkTaskChannelWrapper>,
+        mut channel_receiver: mpsc::UnboundedReceiver<NetworkTaskChannel>,
     ) -> anyhow::Result<KeygenOutput<Secp256k1>> {
         let participant_id = client.my_participant_id();
         let all_participant_ids = client.all_participant_ids();
@@ -136,10 +146,8 @@ mod tests {
                 .await
                 .ok_or_else(|| anyhow::anyhow!("No channel"))?
         };
-        let key = channel
-            .perform_leader_centric_computation(false, move |channel| {
-                run_key_generation(channel, participant_id, 3).boxed()
-            })
+        let key = KeyGenerationComputation { threshold: 3 }
+            .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
             .await?;
 
         Ok(key)

--- a/node/src/key_resharing.rs
+++ b/node/src/key_resharing.rs
@@ -1,7 +1,7 @@
 use crate::config::MpcConfig;
 use crate::indexer::participants::ContractResharingState;
 use crate::keyshare::{KeyshareStorage, RootKeyshareData};
-use crate::network::computation::{MpcLeaderCentricComputation, MpcLeaderCentricComputationExt};
+use crate::network::computation::MpcLeaderCentricComputation;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::{MpcTaskId, ParticipantId};
 use crate::protocol::run_protocol;
@@ -154,7 +154,7 @@ pub fn public_key_to_affine_point(key: near_crypto::PublicKey) -> anyhow::Result
 #[cfg(test)]
 mod tests {
     use crate::key_resharing::KeyResharingComputation;
-    use crate::network::computation::MpcLeaderCentricComputationExt;
+    use crate::network::computation::MpcLeaderCentricComputation;
     use crate::network::testing::run_test_clients;
     use crate::network::{MeshNetworkClient, NetworkTaskChannel};
     use crate::primitives::{MpcTaskId, ParticipantId};

--- a/node/src/mpc_client.rs
+++ b/node/src/mpc_client.rs
@@ -4,7 +4,7 @@ use crate::indexer::handler::ChainSignatureRequest;
 use crate::indexer::types::{ChainRespondArgs, ChainSendTransactionRequest};
 use crate::keyshare::RootKeyshareData;
 use crate::metrics;
-use crate::network::computation::MpcLeaderCentricComputationExt;
+use crate::network::computation::MpcLeaderCentricComputation;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::{MpcTaskId, PresignOutputWithParticipants};
 use crate::sign::{

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -1,14 +1,21 @@
 pub mod conn;
+pub mod constants;
 pub mod handshake;
+pub mod indexer_heights;
 
-use crate::primitives::{BatchedMessages, MpcMessage, MpcPeerMessage, MpcTaskId, ParticipantId};
+use crate::metrics;
+use crate::primitives::{
+    IndexerHeightMessage, MpcMessage, MpcMessageKind, MpcPeerMessage, MpcStartMessage, MpcTaskId,
+    ParticipantId, PeerMessage,
+};
 use crate::tracking::{self, AutoAbortTask};
-use conn::ConnectionVersion;
-use futures_util::future::BoxFuture;
-use futures_util::FutureExt;
+use conn::{ConnectionVersion, NodeConnectivityInterface};
+use futures::future::BoxFuture;
+use indexer_heights::IndexerHeightTracker;
 use lru::LruCache;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
 use std::option::Option;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -18,44 +25,33 @@ use tokio::sync::mpsc;
 /// For a running node, there should be only one such instance that handles all
 /// p2p network communication. This is thread safe; it's expected that there would be
 /// many references to this object via Arc.
-///
-/// TODO(#15): Is this the best API?
 #[async_trait::async_trait]
 pub trait MeshNetworkTransportSender: Send + Sync + 'static {
     /// Returns the participant ID of the current node.
     fn my_participant_id(&self) -> ParticipantId;
     /// Returns the participant IDs of all nodes in the network, including the current node.
     fn all_participant_ids(&self) -> Vec<ParticipantId>;
-    /// Returns a connection version to be used to tell if the connection becomes outdated.
-    fn connection_version(&self, participant_id: ParticipantId) -> ConnectionVersion;
-    /// Returns if the connection to this participant has been reset or dropped since the
-    /// call to connection_version (the result of which is passed in here).
-    fn was_connection_interrupted(
-        &self,
-        participant_id: ParticipantId,
-        connection_version: ConnectionVersion,
-    ) -> bool;
+    /// Returns a connectivity interface for the given other participant.
+    fn connectivity(&self, participant_id: ParticipantId) -> Arc<dyn NodeConnectivityInterface>;
     /// Sends a message to the specified recipient.
-    /// It is not expected to really block. It's only async because messages may be congested.
-    /// Returns an error if something serious goes wrong so that the task that expects the
-    /// message to be sent has no meaningful way to proceed. Otherwise, just because the
-    /// message is sent doesn't guarantee that the recipient will receive it; that is up to
-    /// the user of the networking layer to deal with. This method should fail if the current
-    /// connection version is different from the one supplied (i.e. the connection was reset).
-    async fn send(
+    ///
+    /// For messages M = [m_0, m_1, m_2, ..., m_n] sent via this method to the same recipient
+    /// for which this method returned Ok, it is guaranteed that the recipient will receive
+    /// M[0..i] for some 0 <= i <= n.
+    ///
+    /// The connection_version is used to detect if the connection is broken, in which case
+    /// such a guarantee is no longer possible.
+    fn send(
         &self,
         recipient_id: ParticipantId,
         message: MpcMessage,
         connection_version: ConnectionVersion,
     ) -> anyhow::Result<()>;
+    /// Sends a message to everyone on a best-effort basis about the current height of our indexer.
+    fn send_indexer_height(&self, height: IndexerHeightMessage);
     /// Waits until at least `threshold` nodes in the network have been connected to initially,
     /// the threshold includes ourselves.
     async fn wait_for_ready(&self, threshold: usize) -> anyhow::Result<()>;
-    /// Returns the participant IDs of all nodes in the network that are currently alive.
-    /// This is a subset of all_participant_ids, and includes our own participant ID.
-    fn all_alive_participant_ids(&self) -> Vec<ParticipantId>;
-    /// Emits prometheus metrics regarding the state of connections to other MPC nodes
-    fn emit_metrics(&self);
 }
 
 /// The receiving side of the networking layer. It is expected that the node will run
@@ -63,21 +59,33 @@ pub trait MeshNetworkTransportSender: Send + Sync + 'static {
 /// tokio task to process it.
 #[async_trait::async_trait]
 pub trait MeshNetworkTransportReceiver: Send + 'static {
-    async fn receive(&mut self) -> anyhow::Result<MpcPeerMessage>;
+    async fn receive(&mut self) -> anyhow::Result<PeerMessage>;
 }
 
 /// Concrete logic for a client based on the networking layer.
 /// Manages a collection of MPC tasks so that they can be multiplexed onto the
 /// networking layer underneath.
-#[derive(Clone)]
 pub struct MeshNetworkClient {
     transport_sender: Arc<dyn MeshNetworkTransportSender>,
-    senders_for_tasks: Arc<Mutex<HashMap<MpcTaskId, mpsc::Sender<MpcPeerMessage>>>>,
-    deleted_channels: Arc<Mutex<LruCache<MpcTaskId, ()>>>,
+    channels: Arc<Mutex<NetworkTaskChannelManager>>,
+    indexer_heights: Arc<IndexerHeightTracker>,
+}
+
+struct NetworkTaskChannelManager {
+    senders: HashMap<MpcTaskId, mpsc::UnboundedSender<MpcPeerMessage>>,
+    channels_waiting_for_start: LruCache<MpcTaskId, IncompleteNetworkTaskChannel>,
+}
+
+impl NetworkTaskChannelManager {
+    fn new() -> Self {
+        Self {
+            senders: HashMap::new(),
+            channels_waiting_for_start: LruCache::new(LRU_CAPACITY.try_into().unwrap()),
+        }
+    }
 }
 
 const LRU_CAPACITY: usize = 10000;
-const CHANNEL_SIZE: usize = 10000;
 
 impl MeshNetworkClient {
     /// Primary functionality for the MeshNetworkClient: returns a channel for the given
@@ -88,18 +96,34 @@ impl MeshNetworkClient {
         &self,
         task_id: MpcTaskId,
         participants: Vec<ParticipantId>,
-    ) -> anyhow::Result<NetworkTaskChannel> {
+    ) -> anyhow::Result<NetworkTaskChannelWrapper> {
         tracing::debug!(
             target: "network",
             "[{}] Creating new channel for task {:?}",
             self.my_participant_id(),
             task_id
         );
-        match self.sender_for(task_id, participants) {
-            SenderOrNewChannel::Existing(_) => anyhow::bail!("Channel already exists"),
-            SenderOrNewChannel::NewChannel { channel, .. } => Ok(channel),
-            SenderOrNewChannel::RemovedChannel => anyhow::bail!("Channel was removed"),
+        let start_message = MpcStartMessage {
+            participants: participants.clone(),
+        };
+        let SenderOrNewChannel::NewChannel(channel) =
+            self.sender_for(task_id, Some(&start_message), self.my_participant_id())
+        else {
+            anyhow::bail!("Channel already exists");
+        };
+        for participant in &participants {
+            if participant == &self.my_participant_id() {
+                continue;
+            }
+            channel.sender.send_raw(
+                *participant,
+                MpcMessage {
+                    task_id,
+                    kind: MpcMessageKind::Start(start_message.clone()),
+                },
+            )?;
         }
+        Ok(NetworkTaskChannelWrapper(channel))
     }
 
     pub fn my_participant_id(&self) -> ParticipantId {
@@ -113,7 +137,22 @@ impl MeshNetworkClient {
     /// Returns the participant IDs of all nodes in the network that are currently alive.
     /// This is a subset of all_participant_ids, and includes our own participant ID.
     pub fn all_alive_participant_ids(&self) -> Vec<ParticipantId> {
-        self.transport_sender.all_alive_participant_ids()
+        let mut result = Vec::new();
+        for participant in self.all_participant_ids() {
+            if participant == self.my_participant_id() {
+                continue;
+            }
+            if self
+                .transport_sender
+                .connectivity(participant)
+                .is_bidirectionally_connected()
+            {
+                result.push(participant);
+            }
+        }
+        result.push(self.my_participant_id());
+        result.sort();
+        result
     }
 
     /// Internal function shared between new_channel_for_task and MeshNetworkClientDriver::run.
@@ -124,60 +163,108 @@ impl MeshNetworkClient {
     fn sender_for(
         &self,
         task_id: MpcTaskId,
-        participants: Vec<ParticipantId>,
+        start: Option<&MpcStartMessage>,
+        originator: ParticipantId,
     ) -> SenderOrNewChannel {
-        if self.deleted_channels.lock().unwrap().contains(&task_id) {
-            return SenderOrNewChannel::RemovedChannel;
-        }
-        let mut senders_for_tasks = self.senders_for_tasks.lock().unwrap();
-        match senders_for_tasks.entry(task_id) {
-            Entry::Occupied(entry) => SenderOrNewChannel::Existing(entry.get().clone()),
+        let drop_fn = {
+            let channels = self.channels.clone();
+            move || {
+                channels.lock().unwrap().senders.remove(&task_id);
+            }
+        };
+        let mut channels = self.channels.lock().unwrap();
+        let sender = match channels.senders.entry(task_id) {
+            Entry::Occupied(entry) => entry.get().clone(),
             Entry::Vacant(entry) => {
-                let (sender, receiver) = mpsc::channel(CHANNEL_SIZE);
+                let (sender, receiver) = mpsc::unbounded_channel();
                 entry.insert(sender.clone());
-                drop(senders_for_tasks); // release lock
-
-                let senders_for_tasks = self.senders_for_tasks.clone();
-                let deleted_channels = self.deleted_channels.clone();
-                let drop_fn = move || {
-                    deleted_channels.lock().unwrap().put(task_id, ());
-                    senders_for_tasks.lock().unwrap().remove(&task_id);
-                };
-
-                SenderOrNewChannel::NewChannel {
-                    sender,
-                    channel: NetworkTaskChannel {
-                        task_id,
-                        my_participant_id: self.my_participant_id(),
-                        connection_versions: Arc::new(
-                            participants
-                                .iter()
-                                .map(|id| (*id, self.transport_sender.connection_version(*id)))
-                                .collect(),
-                        ),
-                        sender: self.transport_sender.clone(),
-                        receiver,
-                        drop: Some(Box::new(drop_fn)),
-                        participants,
-                    },
+                let incomplete_channel = IncompleteNetworkTaskChannel { receiver };
+                if let Some((k, _)) = channels
+                    .channels_waiting_for_start
+                    .push(task_id, incomplete_channel)
+                {
+                    if k != task_id {
+                        // Keep channels_waiting_for_start a subset of senders.
+                        channels.senders.remove(&k);
+                    }
                 }
+                sender
+            }
+        };
+        if let Some(start) = start {
+            if let Some(incomplete_channel) = channels.channels_waiting_for_start.pop(&task_id) {
+                drop(channels); // release lock
+                let channel = NetworkTaskChannel {
+                    sender: Arc::new(NetworkTaskChannelSender {
+                        task_id,
+                        leader: originator,
+                        my_participant_id: self.my_participant_id(),
+                        participants: start.participants.clone(),
+                        connection_versions: start
+                            .participants
+                            .iter()
+                            .filter(|id| **id != self.my_participant_id())
+                            .map(|id| {
+                                (
+                                    *id,
+                                    self.transport_sender.connectivity(*id).connection_version(),
+                                )
+                            })
+                            .collect(),
+                        transport_sender: self.transport_sender.clone(),
+                    }),
+                    successful_participants: HashSet::new(),
+                    receiver: incomplete_channel.receiver,
+                    drop: Some(Box::new(drop_fn)),
+                };
+                return SenderOrNewChannel::NewChannel(channel);
             }
         }
+        SenderOrNewChannel::Sender(sender)
     }
 
     /// Emit network metrics through Prometheus counters
     pub fn emit_metrics(&self) {
-        self.transport_sender.emit_metrics();
+        let my_participant_id = self.my_participant_id();
+        metrics::NETWORK_LIVE_CONNECTIONS.reset();
+
+        for id in self.all_participant_ids() {
+            if id == my_participant_id {
+                continue;
+            }
+            let is_live_participant = self
+                .transport_sender
+                .connectivity(id)
+                .is_bidirectionally_connected();
+            metrics::NETWORK_LIVE_CONNECTIONS
+                .with_label_values(&[&my_participant_id.to_string(), &id.to_string()])
+                .set(is_live_participant.into());
+        }
+    }
+
+    // TODO(#226): Use.
+    #[allow(dead_code)]
+    pub fn update_indexer_height(&self, height: u64) {
+        self.indexer_heights
+            .set_height(self.my_participant_id(), height);
+        self.transport_sender
+            .send_indexer_height(IndexerHeightMessage { height });
+    }
+
+    // TODO(#226): Use.
+    #[allow(dead_code)]
+    pub fn get_indexer_heights(&self) -> HashMap<ParticipantId, u64> {
+        self.indexer_heights.get_heights()
     }
 }
 
+struct IncompleteNetworkTaskChannel {
+    receiver: tokio::sync::mpsc::UnboundedReceiver<MpcPeerMessage>,
+}
+
 enum SenderOrNewChannel {
-    Existing(mpsc::Sender<MpcPeerMessage>),
-    NewChannel {
-        sender: mpsc::Sender<MpcPeerMessage>,
-        channel: NetworkTaskChannel,
-    },
-    RemovedChannel,
+    Sender(mpsc::UnboundedSender<MpcPeerMessage>),
+    NewChannel(NetworkTaskChannel),
 }
 
 /// Runs the loop of receiving messages from the transport and dispatching them to the
@@ -186,34 +273,29 @@ enum SenderOrNewChannel {
 async fn run_receive_messages_loop(
     client: Arc<MeshNetworkClient>,
     mut receiver: Box<dyn MeshNetworkTransportReceiver>,
-    new_channel_sender: mpsc::Sender<NetworkTaskChannel>,
+    new_channel_sender: mpsc::UnboundedSender<NetworkTaskChannelWrapper>,
+    indexer_heights: Arc<IndexerHeightTracker>,
 ) -> anyhow::Result<()> {
     loop {
         let message = receiver.receive().await?;
-        let task_id = message.message.task_id;
-        let channel = client.sender_for(task_id, message.message.participants.clone());
-        match channel {
-            SenderOrNewChannel::Existing(sender) => {
-                // Should we try_send in case the channel is full?
-                sender.send(message).await?;
+        match message {
+            PeerMessage::Mpc(message) => {
+                let task_id = message.message.task_id;
+                let start_msg = match &message.message.kind {
+                    MpcMessageKind::Start(start_msg) => Some(start_msg),
+                    _ => None,
+                };
+                match client.sender_for(task_id, start_msg, message.from) {
+                    SenderOrNewChannel::Sender(sender) => {
+                        sender.send(message)?;
+                    }
+                    SenderOrNewChannel::NewChannel(channel) => {
+                        new_channel_sender.send(NetworkTaskChannelWrapper(channel))?;
+                    }
+                }
             }
-            SenderOrNewChannel::NewChannel { channel, sender } => {
-                sender.send(message).await?;
-                tracing::debug!(
-                    target: "network",
-                    "[{}] [Task {:?}] Passively created new channel for task",
-                    client.my_participant_id(),
-                    task_id
-                );
-                new_channel_sender.send(channel).await?;
-            }
-            SenderOrNewChannel::RemovedChannel => {
-                tracing::debug!(
-                    target: "network",
-                    "[{}] [Task {:?}] Ignoring message for removed channel",
-                    client.my_participant_id(),
-                    task_id
-                );
+            PeerMessage::IndexerHeight(message) => {
+                indexer_heights.set_height(message.from, message.message.height);
             }
         }
     }
@@ -227,19 +309,26 @@ pub fn run_network_client(
     transport_receiver: Box<dyn MeshNetworkTransportReceiver>,
 ) -> (
     Arc<MeshNetworkClient>,
-    mpsc::Receiver<NetworkTaskChannel>,
+    mpsc::UnboundedReceiver<NetworkTaskChannelWrapper>,
     AutoAbortTask<()>,
 ) {
-    // TODO: read duration from config
+    let indexer_heights = Arc::new(IndexerHeightTracker::new(
+        &transport_sender.all_participant_ids(),
+    ));
     let client = Arc::new(MeshNetworkClient {
         transport_sender,
-        senders_for_tasks: Arc::new(Mutex::new(HashMap::new())),
-        deleted_channels: Arc::new(Mutex::new(LruCache::new(LRU_CAPACITY.try_into().unwrap()))),
+        channels: Arc::new(Mutex::new(NetworkTaskChannelManager::new())),
+        indexer_heights: indexer_heights.clone(),
     });
-    let (new_channel_sender, new_channel_receiver) = mpsc::channel(CHANNEL_SIZE);
+    let (new_channel_sender, new_channel_receiver) = mpsc::unbounded_channel();
     let handle = tracking::spawn_checked(
         "Network receive message loop",
-        run_receive_messages_loop(client.clone(), transport_receiver, new_channel_sender),
+        run_receive_messages_loop(
+            client.clone(),
+            transport_receiver,
+            new_channel_sender,
+            indexer_heights,
+        ),
     );
     (client, new_channel_receiver, handle)
 }
@@ -250,24 +339,48 @@ pub fn run_network_client(
 /// If the MPC task times out or aborts for any reason, this object must be dropped to ensure
 /// proper cleanup of the associated resources.
 pub struct NetworkTaskChannel {
-    pub task_id: MpcTaskId,
-    my_participant_id: ParticipantId, // for debugging
-    pub participants: Vec<ParticipantId>,
-    connection_versions: Arc<HashMap<ParticipantId, ConnectionVersion>>,
-    sender: Arc<dyn MeshNetworkTransportSender>,
-    receiver: tokio::sync::mpsc::Receiver<MpcPeerMessage>,
+    sender: Arc<NetworkTaskChannelSender>,
+    /// Used for calling receive(&mut self).
+    receiver: tokio::sync::mpsc::UnboundedReceiver<MpcPeerMessage>,
+    /// The set of participants who sent us a Success message; for leader only.
+    successful_participants: HashSet<ParticipantId>,
+    /// Function to clean up relevant data structures in the network transport implementation.
     drop: Option<Box<dyn FnOnce() + Send + Sync>>,
 }
 
-type SendFnForTaskChannel = Arc<
-    dyn Fn(
-            ParticipantId,
-            BatchedMessages,
-            Vec<ParticipantId>,
-        ) -> BoxFuture<'static, anyhow::Result<()>>
-        + Send
-        + Sync,
->;
+/// A subset of the NetworkTaskChannel that doesn't include the mutable parts.
+pub struct NetworkTaskChannelSender {
+    /// The task ID associated with the computation.
+    task_id: MpcTaskId,
+    /// The leader of the computation; there is exactly one leader for each computation.
+    leader: ParticipantId,
+    /// The participant ID of our node.
+    my_participant_id: ParticipantId,
+    /// The participant IDs of all participants in the computation, including our own.
+    participants: Vec<ParticipantId>,
+    /// The version of the connection we have with each other participant.
+    /// This is used to detect dropped connections. See ConnectionVersion for details.
+    connection_versions: HashMap<ParticipantId, ConnectionVersion>,
+    /// The underlying transport layer.
+    transport_sender: Arc<dyn MeshNetworkTransportSender>,
+}
+
+/// A wrapper around NetworkTaskChannel,
+pub struct NetworkTaskChannelWrapper(NetworkTaskChannel);
+
+impl Deref for NetworkTaskChannelWrapper {
+    type Target = NetworkTaskChannel;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// A computation data message received from a participant.
+pub struct TaskChannelComputationData {
+    pub from: ParticipantId,
+    pub data: Vec<Vec<u8>>,
+}
 
 impl Drop for NetworkTaskChannel {
     fn drop(&mut self) {
@@ -277,11 +390,22 @@ impl Drop for NetworkTaskChannel {
     }
 }
 
-impl NetworkTaskChannel {
-    /// Returns a sender to be used to send a message to another participant in the MPC task.
-    ///
-    /// Documentation for the sender function returned:
-    ///
+impl NetworkTaskChannelSender {
+    /// Sends a raw MpcMessage to the participant over the network.
+    /// It fails if the connection is not established to the participant, or if the connection is
+    /// a different one from the original when the channel was created.
+    fn send_raw(&self, recipient_id: ParticipantId, message: MpcMessage) -> anyhow::Result<()> {
+        self.transport_sender.send(
+            recipient_id,
+            message,
+            self.connection_versions
+                .get(&recipient_id)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("No connection version for recipient"))?,
+        )?;
+        Ok(())
+    }
+
     /// Sends a message to another participant in the MPC task.
     /// Returns an error only if there is something seriously wrong with the networking layer so
     /// that there's no meaningful way for the MPC task to proceed.
@@ -293,88 +417,304 @@ impl NetworkTaskChannel {
     ///
     /// The implementation of this function will guarantee that all messages sent are encrypted,
     /// i.e. can only be decrypted by the recipient.
-    pub fn sender(&self) -> SendFnForTaskChannel {
-        let transport_sender = self.sender.clone();
-        let connection_versions = self.connection_versions.clone();
-        let task_id = self.task_id;
-        Arc::new(
-            move |recipient_id, message, participants: Vec<ParticipantId>| {
-                let transport_sender = transport_sender.clone();
-                let connection_versions = connection_versions.clone();
-                async move {
-                    transport_sender
-                        .send(
-                            recipient_id,
-                            MpcMessage {
-                                task_id,
-                                data: message,
-                                participants,
-                            },
-                            connection_versions
-                                .get(&recipient_id)
-                                .copied()
-                                .ok_or_else(|| {
-                                    anyhow::anyhow!("No connection version for recipient")
-                                })?,
-                        )
-                        .await?;
-                    Ok(())
-                }
-                .boxed()
+    pub fn send(&self, recipient_id: ParticipantId, data: Vec<Vec<u8>>) -> anyhow::Result<()> {
+        self.send_raw(
+            recipient_id,
+            MpcMessage {
+                task_id: self.task_id,
+                kind: MpcMessageKind::Computation(data),
             },
         )
     }
 
-    /// Receives a message from another participant in the MPC task.
+    pub fn is_leader(&self) -> bool {
+        self.my_participant_id == self.leader
+    }
+
+    /// Waits for all participants involved in this task to be bidirectionally connected to us.
+    /// This should be called at the beginning of the computation if:
+    ///  - This is a leader-centric computation, and we are a follower.
+    ///    (Rationale: the leader already determined that the participants are online. We wait
+    ///     for connections because even though the leader has connected to everyone, it is
+    ///     possible we have yet to establish connections to everyone. We assume that if the
+    ///     leader can connect to two nodes B and C, then B and C can also connect to each other.)
     ///
-    /// Messages from the same sender are guaranteed to be received in the same order they were
-    /// sent. However, messages from different senders may be received in arbitrary order.
-    ///
-    /// Returns an error if the networking client is dropped (during node shutdown).
-    ///
-    /// This future may never resolve if the MPC computation fails to progress (i.e. all clients
-    /// decide they need to receive a message before sending one). It is up to the caller to
-    /// implement a timeout mechanism. However, if we notice that not all participants of the
-    /// computation are online anymore, this method will return an error soon.
-    pub async fn receive(&mut self) -> anyhow::Result<MpcPeerMessage> {
-        loop {
+    /// This should NOT be called if:
+    ///  - We are the leader. This is redundant because the leader already queried the alive
+    ///    participants when making the choice of participants to use in the computation.
+    async fn wait_for_all_participants_connected(&self) -> anyhow::Result<()> {
+        for &participant in &self.participants {
+            if participant == self.my_participant_id {
+                continue;
+            }
+            tracking::set_progress(&format!("Waiting for connection to {}", participant));
+            self.transport_sender
+                .connectivity(participant)
+                .wait_for_connection(self.connection_versions[&participant])
+                .await?;
+        }
+        tracking::set_progress("All participants connected");
+        Ok(())
+    }
+
+    /// This is called at the end of a leader-centric computation to communicate the result to
+    /// other parties. For leaders, only failures are communicated to followers; for followers,
+    /// failures are communicated to the leader, and if leader waits for success, also
+    /// communicate successes to the leader.
+    fn communicate_result<T>(
+        &self,
+        result: &anyhow::Result<T>,
+        leader_waits_for_success: bool,
+    ) -> anyhow::Result<()> {
+        match result {
+            Ok(_) => {
+                if !self.is_leader() && leader_waits_for_success {
+                    tracing::debug!(
+                        target: "network",
+                        "[{}] [Task {:?}] Sending Success message to leader {}",
+                        self.my_participant_id,
+                        self.task_id,
+                        self.leader
+                    );
+                    self.send_raw(
+                        self.leader,
+                        MpcMessage {
+                            task_id: self.task_id,
+                            kind: MpcMessageKind::Success,
+                        },
+                    )?;
+                }
+            }
+            Err(err) => {
+                let err_msg = err.to_string();
+                if self.is_leader() {
+                    for participant in &self.participants {
+                        if participant == &self.my_participant_id {
+                            continue;
+                        }
+
+                        tracing::debug!(
+                            target: "network",
+                            "[{}] [Task {:?}] Sending Abort message to participant {}",
+                            self.my_participant_id,
+                            self.task_id,
+                            participant
+                        );
+                        // Don't fail just because we cannot send an abort message.
+                        let _ = self.send_raw(
+                            *participant,
+                            MpcMessage {
+                                task_id: self.task_id,
+                                kind: MpcMessageKind::Abort(err_msg.clone()),
+                            },
+                        );
+                    }
+                } else {
+                    tracing::debug!(
+                        target: "network",
+                        "[{}] [Task {:?}] Sending Abort message to leader {}",
+                        self.my_participant_id,
+                        self.task_id,
+                        self.leader
+                    );
+                    // Don't fail just because we cannot send an abort message.
+                    let _ = self.send_raw(
+                        self.leader,
+                        MpcMessage {
+                            task_id: self.task_id,
+                            kind: MpcMessageKind::Abort(err_msg),
+                        },
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl NetworkTaskChannel {
+    /// Returns a sender to be used to send a message to another participant in the MPC task.
+    pub fn sender(&self) -> Arc<NetworkTaskChannelSender> {
+        self.sender.clone()
+    }
+
+    pub fn task_id(&self) -> MpcTaskId {
+        self.sender.task_id
+    }
+
+    pub fn participants(&self) -> &[ParticipantId] {
+        &self.sender.participants
+    }
+
+    pub fn my_participant_id(&self) -> ParticipantId {
+        self.sender.my_participant_id
+    }
+
+    /// Receives a single MPC message from any participant from the network, without processing it.
+    /// This will return error early if any connection is broken.
+    async fn receive_raw(&mut self) -> anyhow::Result<MpcPeerMessage> {
+        let received = loop {
             let timer = tokio::time::sleep(Duration::from_secs(1));
+
             tokio::select! {
                 _ = timer => {
-                    if self.connection_versions.iter().any(|(id, version)| {
-                        self.sender.was_connection_interrupted(*id, *version)
+                    if self.sender.connection_versions.iter().any(|(id, version)| {
+                        self.sender.transport_sender.connectivity(*id).was_connection_interrupted(*version)
                     }) {
                         anyhow::bail!("Computation cannot succeed as not all participants are alive anymore");
                     }
                 }
-                result = self.receiver.recv() => {
-                    let Some(result) = result else {
+                received = self.receiver.recv() => {
+                    let Some(received) = received else {
                         anyhow::bail!("Channel closed");
                     };
-                    tracing::debug!(
-                        target: "network",
-                        "[{}] [Task {:?}] Received message: {:?}",
-                        self.my_participant_id, self.task_id, result
-                    );
-                    return Ok(result);
+                    break received;
                 }
             }
+        };
+
+        tracing::debug!(
+            target: "network",
+            "[{}] [Task {:?}] Received message: {:?}",
+            self.sender.my_participant_id, self.sender.task_id, received
+        );
+        Ok(received)
+    }
+
+    /// Receives one message from the network and process it; that message may or may not be a
+    /// computation message.
+    async fn receive_one(&mut self) -> anyhow::Result<Option<TaskChannelComputationData>> {
+        let message = self.receive_raw().await?;
+        match message.message.kind {
+            MpcMessageKind::Computation(data) => {
+                return Ok(Some(TaskChannelComputationData {
+                    from: message.from,
+                    data,
+                }))
+            }
+            MpcMessageKind::Abort(err) => {
+                tracing::debug!(
+                    target: "network",
+                    "[{}] [Task {:?}] Received abort from participant {}: {}",
+                    self.sender.my_participant_id,
+                    self.sender.task_id,
+                    message.from,
+                    err
+                );
+                if self.sender.is_leader() {
+                    anyhow::bail!("Aborted by participant {}: {}", message.from, err);
+                } else {
+                    anyhow::bail!("Aborted by leader: {}", err);
+                }
+            }
+            MpcMessageKind::Success => {
+                tracing::debug!(
+                    target: "network",
+                    "[{}] [Task {:?}] Received success from participant {}",
+                    self.sender.my_participant_id,
+                    self.sender.task_id,
+                    message.from
+                );
+                if self.sender.is_leader() {
+                    self.successful_participants.insert(message.from);
+                } else {
+                    anyhow::bail!("Unexpected Success message from leader");
+                }
+            }
+            MpcMessageKind::Start(mpc_start_message) => {
+                anyhow::bail!("Unexpected Start message: {:?}", mpc_start_message);
+            }
         }
+        Ok(None)
+    }
+
+    /// Receives a computation message from another participant.
+    /// Blocks until a message is received, but will return early if:
+    ///   - Any connection to any participant is broken.
+    ///   - The computation is aborted by a follower (if we're the leader) or the leader
+    ///     (if we're a follower).
+    pub async fn receive(&mut self) -> anyhow::Result<TaskChannelComputationData> {
+        loop {
+            if let Some(data) = self.receive_one().await? {
+                return Ok(data);
+            }
+        }
+    }
+
+    /// The leader may call this to wait for all followers to succeed.
+    /// This will return error if any connection is broken, or if any follower ends up
+    /// sending the leader an Abort message instead.
+    async fn wait_for_followers_to_succeed(&mut self) -> anyhow::Result<()> {
+        if !self.sender.is_leader() {
+            anyhow::bail!("Only the leader can wait for others to succeed");
+        }
+        while self.successful_participants.len() < self.sender.participants.len() - 1 {
+            tracking::set_progress(&format!(
+                "Waiting for followers to succeed: {} out of {}",
+                self.successful_participants.len(),
+                self.sender.participants.len() - 1
+            ));
+            let _ = self.receive_one().await?;
+        }
+        tracking::set_progress("All followers succeeded");
+        Ok(())
+    }
+}
+
+impl NetworkTaskChannelWrapper {
+    /// Perform the given computation in a leader-centric way:
+    ///  - If any follower's computation returns error, it automatically sends an Abort message to
+    ///    the leader, causing the leader to fail as well.
+    ///  - If the leader's computation returns error, it automatically sends an Abort message to
+    ///    all followers, causing their computation to fail as well.
+    ///
+    /// If leader_waits_for_success is true, then additionally:
+    ///  - Followers who succeed send a Success message to the leader.
+    ///  - The leader will wait for all Success messages before returning.
+    pub async fn perform_leader_centric_computation<R: Send + 'static>(
+        self,
+        leader_waits_for_success: bool,
+        f: impl for<'a> FnOnce(&'a mut NetworkTaskChannel) -> BoxFuture<'a, anyhow::Result<R>>
+            + Send
+            + 'static,
+    ) -> anyhow::Result<R> {
+        let mut channel = self.0;
+        let sender = channel.sender();
+        if !sender.is_leader() {
+            sender.wait_for_all_participants_connected().await?;
+        }
+        let result = f(&mut channel).await;
+        let result = match result {
+            Ok(result) => result,
+            err @ Err(_) => {
+                sender.communicate_result(&err, leader_waits_for_success)?;
+                return err;
+            }
+        };
+        if leader_waits_for_success && sender.is_leader() {
+            if let err @ Err(_) = channel.wait_for_followers_to_succeed().await {
+                sender.communicate_result(&err, leader_waits_for_success)?;
+                err?;
+            }
+        }
+        sender.communicate_result(&Ok(()), leader_waits_for_success)?;
+        tracking::set_progress("Computation complete");
+        Ok(result)
     }
 }
 
 #[cfg(test)]
 pub mod testing {
-    use super::conn::ConnectionVersion;
+    use super::conn::{ConnectionVersion, NodeConnectivityInterface};
     use super::MeshNetworkTransportSender;
-    use crate::primitives::{MpcPeerMessage, ParticipantId};
+    use crate::primitives::{MpcPeerMessage, ParticipantId, PeerMessage};
     use crate::tracking;
     use std::collections::HashMap;
     use std::sync::Arc;
 
     pub struct TestMeshTransport {
         participant_ids: Vec<ParticipantId>,
-        senders: HashMap<ParticipantId, tokio::sync::mpsc::UnboundedSender<MpcPeerMessage>>,
+        senders: HashMap<ParticipantId, tokio::sync::mpsc::UnboundedSender<PeerMessage>>,
     }
 
     pub struct TestMeshTransportSender {
@@ -383,7 +723,31 @@ pub mod testing {
     }
 
     pub struct TestMeshTransportReceiver {
-        receiver: tokio::sync::mpsc::UnboundedReceiver<MpcPeerMessage>,
+        receiver: tokio::sync::mpsc::UnboundedReceiver<PeerMessage>,
+    }
+
+    pub struct TestConnectivityInterface;
+
+    #[async_trait::async_trait]
+    impl NodeConnectivityInterface for TestConnectivityInterface {
+        fn is_bidirectionally_connected(&self) -> bool {
+            true
+        }
+
+        async fn wait_for_connection(
+            &self,
+            _connection_version: ConnectionVersion,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn was_connection_interrupted(&self, _connection_version: ConnectionVersion) -> bool {
+            false
+        }
+
+        fn connection_version(&self) -> ConnectionVersion {
+            ConnectionVersion::default()
+        }
     }
 
     #[async_trait::async_trait]
@@ -396,22 +760,14 @@ pub mod testing {
             self.transport.participant_ids.clone()
         }
 
-        fn connection_version(&self, _participant_id: ParticipantId) -> ConnectionVersion {
-            ConnectionVersion {
-                incoming: 0,
-                outgoing: 0,
-            }
-        }
-
-        fn was_connection_interrupted(
+        fn connectivity(
             &self,
             _participant_id: ParticipantId,
-            _connection_version: ConnectionVersion,
-        ) -> bool {
-            false
+        ) -> Arc<dyn NodeConnectivityInterface> {
+            Arc::new(TestConnectivityInterface)
         }
 
-        async fn send(
+        fn send(
             &self,
             recipient_id: ParticipantId,
             message: crate::primitives::MpcMessage,
@@ -421,29 +777,25 @@ pub mod testing {
                 .senders
                 .get(&recipient_id)
                 .ok_or_else(|| anyhow::anyhow!("Unknown recipient"))?
-                .send(MpcPeerMessage {
+                .send(PeerMessage::Mpc(MpcPeerMessage {
                     from: self.my_participant_id,
                     message,
-                })?;
+                }))?;
             Ok(())
+        }
+
+        fn send_indexer_height(&self, _height: crate::primitives::IndexerHeightMessage) {
+            // TODO(#226): Test this.
         }
 
         async fn wait_for_ready(&self, _threshold: usize) -> anyhow::Result<()> {
             Ok(())
         }
-
-        fn all_alive_participant_ids(&self) -> Vec<ParticipantId> {
-            self.all_participant_ids()
-        }
-
-        fn emit_metrics(&self) {
-            panic!("emit_metrics should not be called");
-        }
     }
 
     #[async_trait::async_trait]
     impl super::MeshNetworkTransportReceiver for TestMeshTransportReceiver {
-        async fn receive(&mut self) -> anyhow::Result<MpcPeerMessage> {
+        async fn receive(&mut self) -> anyhow::Result<PeerMessage> {
             self.receiver
                 .recv()
                 .await
@@ -491,7 +843,7 @@ pub mod testing {
     where
         F: Fn(
             Arc<super::MeshNetworkClient>,
-            tokio::sync::mpsc::Receiver<super::NetworkTaskChannel>,
+            tokio::sync::mpsc::UnboundedReceiver<super::NetworkTaskChannelWrapper>,
         ) -> FR,
         FR: std::future::Future<Output = anyhow::Result<T>> + Send + 'static,
     {
@@ -519,14 +871,15 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
-    use super::{MeshNetworkClient, NetworkTaskChannel};
+    use super::{MeshNetworkClient, NetworkTaskChannel, NetworkTaskChannelWrapper};
     use crate::assets::UniqueId;
     use crate::network::testing::run_test_clients;
-    use crate::primitives::{MpcTaskId, ParticipantId};
+    use crate::primitives::MpcTaskId;
     use crate::tests::TestGenerators;
     use crate::tracking::testing::start_root_task_with_periodic_dump;
     use crate::tracking::{self, AutoAbortTaskCollection};
     use borsh::{BorshDeserialize, BorshSerialize};
+    use futures::FutureExt;
     use std::collections::HashSet;
     use std::sync::Arc;
     use tokio::sync::mpsc;
@@ -546,7 +899,7 @@ mod tests {
 
     async fn run_test_client(
         client: Arc<MeshNetworkClient>,
-        mut channel_receiver: mpsc::Receiver<NetworkTaskChannel>,
+        mut channel_receiver: mpsc::UnboundedReceiver<NetworkTaskChannelWrapper>,
     ) -> anyhow::Result<()> {
         let _passive_handle = tracking::spawn("monitor passive channels", async move {
             let mut tasks = AutoAbortTaskCollection::new();
@@ -555,8 +908,10 @@ mod tests {
                     break;
                 };
                 tasks.spawn_checked(
-                    &format!("passive task {:?}", channel.task_id),
-                    task_follower(channel),
+                    &format!("passive task {:?}", channel.task_id()),
+                    channel.perform_leader_centric_computation(true, move |channel| {
+                        task_follower(channel).boxed()
+                    }),
                 );
             }
         });
@@ -580,7 +935,9 @@ mod tests {
             )?;
             handles.push(tracking::spawn(
                 &format!("task {}", seed),
-                task_leader(channel, other_participant_ids.clone(), seed),
+                channel.perform_leader_centric_computation(true, move |channel| {
+                    task_leader(channel, seed).boxed()
+                }),
             ));
 
             let expected_total: u64 = other_participant_ids
@@ -602,59 +959,221 @@ mod tests {
         Ok(())
     }
 
-    async fn task_leader(
-        mut channel: NetworkTaskChannel,
-        participants: Vec<ParticipantId>,
-        seed: u64,
-    ) -> anyhow::Result<u64> {
-        for other_participant_id in &participants {
-            channel.sender()(
+    async fn task_leader(channel: &mut NetworkTaskChannel, seed: u64) -> anyhow::Result<u64> {
+        for other_participant_id in channel.participants() {
+            if other_participant_id == &channel.my_participant_id() {
+                continue;
+            }
+            channel.sender().send(
                 *other_participant_id,
                 vec![borsh::to_vec(&TestTripleMessage {
                     data: other_participant_id.raw() as u64 + seed,
                 })
                 .unwrap()],
-                channel.participants.clone(),
-            )
-            .await?;
+            )?;
         }
         let mut total = 0;
         let mut heard_from = HashSet::new();
-        for _ in 0..participants.len() {
+        for _ in 1..channel.participants().len() {
             let msg = channel.receive().await?;
             assert!(heard_from.insert(msg.from));
-            let inner: TestTripleMessage = borsh::from_slice(&msg.message.data[0])?;
+            let inner: TestTripleMessage = borsh::from_slice(&msg.data[0])?;
             total += inner.data;
         }
         Ok(total)
     }
 
-    async fn task_follower(mut channel: NetworkTaskChannel) -> anyhow::Result<()> {
-        println!("Task follower started: task id: {:?}", channel.task_id);
-        match channel.task_id {
-            id @ MpcTaskId::ManyTriples { .. } => {
-                let message = channel.receive().await?;
-                assert_eq!(message.message.task_id, id);
-
-                let inner: TestTripleMessage = borsh::from_slice(&message.message.data[0])?;
-                channel.sender()(
-                    message.from,
+    async fn task_follower(channel: &mut NetworkTaskChannel) -> anyhow::Result<()> {
+        println!("Task follower started: task id: {:?}", channel.task_id());
+        match channel.task_id() {
+            MpcTaskId::ManyTriples { .. } => {
+                let msg = channel.receive().await?;
+                let inner: TestTripleMessage = borsh::from_slice(&msg.data[0])?;
+                channel.sender().send(
+                    msg.from,
                     vec![borsh::to_vec(&TestTripleMessage {
                         data: (inner.data * inner.data) % MOD,
                     })
                     .unwrap()],
-                    channel.participants.clone(),
-                )
-                .await?;
-
-                Ok(())
+                )?;
             }
             _ => unreachable!(),
         }
+        Ok(())
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
     struct TestTripleMessage {
         data: u64,
+    }
+}
+
+#[cfg(test)]
+mod fault_handling_tests {
+    use super::{MeshNetworkClient, NetworkTaskChannel, NetworkTaskChannelWrapper};
+    use crate::assets::UniqueId;
+    use crate::network::testing::run_test_clients;
+    use crate::primitives::{MpcTaskId, ParticipantId};
+    use crate::tests::TestGenerators;
+    use crate::tracking::testing::start_root_task_with_periodic_dump;
+    use futures::FutureExt;
+    use near_o11y::testonly::init_integration_logger;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn test_network_fault_handling() {
+        init_integration_logger();
+        let test_cases = vec![
+            FaultTestCase::NoFault,
+            FaultTestCase::Crash(ParticipantId::from_raw(0)),
+            FaultTestCase::Crash(ParticipantId::from_raw(2)),
+            FaultTestCase::Slow(ParticipantId::from_raw(0), CancellationToken::new()),
+            FaultTestCase::Slow(ParticipantId::from_raw(3), CancellationToken::new()),
+            FaultTestCase::SlowNoWaitSuccess(ParticipantId::from_raw(1), CancellationToken::new()),
+        ];
+        for test_case in test_cases {
+            tracing::info!("Running test case: {:?}", test_case);
+            let test_case = Arc::new(test_case);
+            start_root_task_with_periodic_dump(async move {
+                run_test_clients(
+                    TestGenerators::new_contiguous_participant_ids(4, 3).participant_ids(),
+                    move |client, channel_receiver| {
+                        let test_case = test_case.clone();
+                        async move {
+                            run_fault_handling_test_client(client, channel_receiver, test_case)
+                                .await
+                        }
+                    },
+                )
+                .await
+                .unwrap();
+            })
+            .await;
+        }
+    }
+
+    #[derive(Debug)]
+    enum FaultTestCase {
+        /// All parties succeed.
+        NoFault,
+        /// One party crashes.
+        Crash(ParticipantId),
+        /// One party is slow in the computation.
+        Slow(ParticipantId, CancellationToken),
+        /// One party is slow, but the leader does not wait for successes.
+        SlowNoWaitSuccess(ParticipantId, CancellationToken),
+    }
+
+    async fn run_fault_handling_test_client(
+        client: Arc<MeshNetworkClient>,
+        mut channel_receiver: mpsc::UnboundedReceiver<NetworkTaskChannelWrapper>,
+        test_case: Arc<FaultTestCase>,
+    ) -> anyhow::Result<()> {
+        let me = client.my_participant_id();
+
+        let is_leader = client.my_participant_id().raw() == 0;
+        let channel = if is_leader {
+            client.new_channel_for_task(
+                MpcTaskId::ManyTriples {
+                    start: UniqueId::new(me, 0, 0),
+                    count: 1,
+                },
+                client.all_participant_ids(),
+            )?
+        } else {
+            channel_receiver.recv().await.unwrap()
+        };
+
+        let leader_waits_for_success =
+            !matches!(test_case.as_ref(), FaultTestCase::SlowNoWaitSuccess(_, _));
+        let result = {
+            let test_case = test_case.clone();
+            channel
+                .perform_leader_centric_computation(leader_waits_for_success, move |channel| {
+                    task(channel, test_case).boxed()
+                })
+                .await
+        };
+
+        match test_case.as_ref() {
+            FaultTestCase::NoFault => {
+                assert!(result.is_ok());
+            }
+            FaultTestCase::Crash(participant_id) => {
+                assert!(result.is_err());
+                let err_string = result.as_ref().unwrap_err().to_string();
+                assert!(err_string.contains("Crashed"), "{}", err_string);
+                if participant_id == &client.my_participant_id() {
+                } else if me.raw() == 0 {
+                    assert!(
+                        err_string.contains(&format!("Aborted by participant {}", participant_id)),
+                        "{}",
+                        err_string
+                    );
+                } else {
+                    assert!(err_string.contains("Aborted by leader"), "{}", err_string);
+                }
+            }
+            FaultTestCase::Slow(participant_id, cancellation_token) => {
+                assert!(result.is_ok());
+                if is_leader || *participant_id == client.my_participant_id() {
+                    assert!(cancellation_token.is_cancelled());
+                } else {
+                    assert!(!cancellation_token.is_cancelled());
+                }
+            }
+            FaultTestCase::SlowNoWaitSuccess(participant_id, cancellation_token) => {
+                assert!(result.is_ok());
+                if *participant_id == client.my_participant_id() {
+                    assert!(cancellation_token.is_cancelled());
+                } else {
+                    assert!(!cancellation_token.is_cancelled());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_recv_all(channel: &mut NetworkTaskChannel) -> anyhow::Result<()> {
+        let participants = channel.participants();
+        for participant in participants {
+            if participant == &channel.my_participant_id() {
+                continue;
+            }
+            channel.sender().send(*participant, vec![vec![]])?;
+        }
+        for _ in 1..participants.len() {
+            channel.receive().await?;
+        }
+        Ok(())
+    }
+
+    async fn task(
+        channel: &mut NetworkTaskChannel,
+        test_case: Arc<FaultTestCase>,
+    ) -> anyhow::Result<()> {
+        match test_case.as_ref() {
+            FaultTestCase::NoFault => {
+                send_recv_all(channel).await?;
+            }
+            FaultTestCase::Crash(participant_id) => {
+                if channel.my_participant_id() == *participant_id {
+                    anyhow::bail!("Crashed");
+                } else {
+                    send_recv_all(channel).await?;
+                }
+            }
+            FaultTestCase::Slow(participant_id, cancellation_token)
+            | FaultTestCase::SlowNoWaitSuccess(participant_id, cancellation_token) => {
+                send_recv_all(channel).await?;
+                if channel.my_participant_id() == *participant_id {
+                    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                    cancellation_token.cancel();
+                }
+            }
+        }
+        Ok(())
     }
 }

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -245,16 +245,17 @@ impl MeshNetworkClient {
         metrics::NETWORK_LIVE_CONNECTIONS.reset();
 
         for id in self.all_participant_ids() {
+            let metric = metrics::NETWORK_LIVE_CONNECTIONS
+                .with_label_values(&[&my_participant_id.to_string(), &id.to_string()]);
             if id == my_participant_id {
-                continue;
+                metric.set(1);
+            } else {
+                let is_live_participant = self
+                    .transport_sender
+                    .connectivity(id)
+                    .is_bidirectionally_connected();
+                metric.set(is_live_participant.into());
             }
-            let is_live_participant = self
-                .transport_sender
-                .connectivity(id)
-                .is_bidirectionally_connected();
-            metrics::NETWORK_LIVE_CONNECTIONS
-                .with_label_values(&[&my_participant_id.to_string(), &id.to_string()])
-                .set(is_live_participant.into());
         }
     }
 

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -824,7 +824,6 @@ mod tests {
     use super::computation::MpcLeaderCentricComputation;
     use super::{MeshNetworkClient, NetworkTaskChannel};
     use crate::assets::UniqueId;
-    use crate::network::computation::MpcLeaderCentricComputationExt;
     use crate::network::testing::run_test_clients;
     use crate::primitives::MpcTaskId;
     use crate::tests::TestGenerators;
@@ -982,7 +981,7 @@ mod tests {
 
 #[cfg(test)]
 mod fault_handling_tests {
-    use super::computation::{MpcLeaderCentricComputation, MpcLeaderCentricComputationExt};
+    use super::computation::MpcLeaderCentricComputation;
     use super::{MeshNetworkClient, NetworkTaskChannel};
     use crate::assets::UniqueId;
     use crate::network::testing::run_test_clients;

--- a/node/src/network/computation.rs
+++ b/node/src/network/computation.rs
@@ -1,0 +1,85 @@
+use super::NetworkTaskChannel;
+use crate::tracking;
+use std::future::Future;
+
+/// Interface for a computation that is leader-centric:
+///  - If any follower's computation returns error, it automatically sends an Abort message to
+///    the leader, causing the leader to fail as well.
+///  - If the leader's computation returns error, it automatically sends an Abort message to
+///    all followers, causing their computation to fail as well.
+///
+/// If leader_waits_for_success returns true, then additionally:
+///  - Followers who succeed send a Success message to the leader.
+///  - The leader will wait for all Success messages before returning.
+///
+/// The leader_waits_for_success is for asset generation, where the owner of the asset wants
+/// to only mark it as completed when all followers have persisted their share of the asset.
+#[async_trait::async_trait]
+pub trait MpcLeaderCentricComputation<T>: 'static {
+    /// Performs the computation itself, without worrying about failure propagation or
+    /// waiting for success of followers.
+    async fn compute(self, channel: &mut NetworkTaskChannel) -> anyhow::Result<T>;
+    fn leader_waits_for_success(&self) -> bool;
+}
+
+pub trait MpcLeaderCentricComputationExt<T> {
+    fn perform_leader_centric_computation(
+        self,
+        channel: NetworkTaskChannel,
+        timeout: std::time::Duration,
+    ) -> impl Future<Output = anyhow::Result<T>> + 'static;
+}
+
+impl<T, C: MpcLeaderCentricComputation<T>> MpcLeaderCentricComputationExt<T> for C {
+    fn perform_leader_centric_computation(
+        self,
+        mut channel: NetworkTaskChannel,
+        timeout: std::time::Duration,
+    ) -> impl Future<Output = anyhow::Result<T>> + 'static {
+        let leader_waits_for_success = self.leader_waits_for_success();
+        let sender = channel.sender();
+        let sender_clone = sender.clone();
+
+        // We'll wrap the following future in a timeout below.
+        let fut = async move {
+            if !sender.is_leader() {
+                sender.wait_for_all_participants_connected().await?;
+            }
+            let result = self.compute(&mut channel).await;
+            let result = match result {
+                Ok(result) => result,
+                Err(err) => {
+                    sender.communicate_failure(&err);
+                    return Err(err);
+                }
+            };
+            if leader_waits_for_success && sender.is_leader() {
+                if let Err(err) = channel.wait_for_followers_to_succeed().await {
+                    sender.communicate_failure(&err);
+                    return Err(err);
+                }
+            }
+            Ok(result)
+        };
+
+        async move {
+            let sender = sender_clone;
+            let result = tokio::time::timeout(timeout, fut).await;
+            let result = match result {
+                Ok(result) => result,
+                Err(_) => {
+                    let err = anyhow::anyhow!("Timeout");
+                    sender.communicate_failure(&err);
+                    return Err(err);
+                }
+            };
+            if result.is_ok() {
+                if !sender.is_leader() && leader_waits_for_success {
+                    sender.communicate_success()?;
+                }
+                tracking::set_progress("Computation complete");
+            }
+            result
+        }
+    }
+}

--- a/node/src/network/computation.rs
+++ b/node/src/network/computation.rs
@@ -15,22 +15,13 @@ use std::future::Future;
 /// The leader_waits_for_success is for asset generation, where the owner of the asset wants
 /// to only mark it as completed when all followers have persisted their share of the asset.
 #[async_trait::async_trait]
-pub trait MpcLeaderCentricComputation<T>: 'static {
+pub trait MpcLeaderCentricComputation<T>: Sized + 'static {
     /// Performs the computation itself, without worrying about failure propagation or
     /// waiting for success of followers.
     async fn compute(self, channel: &mut NetworkTaskChannel) -> anyhow::Result<T>;
     fn leader_waits_for_success(&self) -> bool;
-}
 
-pub trait MpcLeaderCentricComputationExt<T> {
-    fn perform_leader_centric_computation(
-        self,
-        channel: NetworkTaskChannel,
-        timeout: std::time::Duration,
-    ) -> impl Future<Output = anyhow::Result<T>> + 'static;
-}
-
-impl<T, C: MpcLeaderCentricComputation<T>> MpcLeaderCentricComputationExt<T> for C {
+    /// Performs the computation. DO NOT override this function.
     fn perform_leader_centric_computation(
         self,
         mut channel: NetworkTaskChannel,

--- a/node/src/network/constants.rs
+++ b/node/src/network/constants.rs
@@ -1,0 +1,4 @@
+/// Maximum length of a single network message. This is a security measure
+/// to prevent a malicious node from sending a huge message that would
+/// cause OOM errors.
+pub const MAX_MESSAGE_LEN: u32 = 100 * 1024 * 1024;

--- a/node/src/network/indexer_heights.rs
+++ b/node/src/network/indexer_heights.rs
@@ -1,0 +1,39 @@
+use crate::primitives::ParticipantId;
+use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
+
+/// Tracks the block height of the indexer of each participant.
+pub struct IndexerHeightTracker {
+    /// Keys are readonly; values are updated atomically.
+    pub heights: HashMap<ParticipantId, AtomicU64>,
+}
+
+impl IndexerHeightTracker {
+    pub fn new(participants: &[ParticipantId]) -> Self {
+        let mut heights = HashMap::new();
+        for participant in participants {
+            heights.insert(*participant, AtomicU64::new(0));
+        }
+        Self { heights }
+    }
+
+    pub fn set_height(&self, participant: ParticipantId, height: u64) {
+        let atomic = self.heights.get(&participant).unwrap();
+        let current = atomic.load(std::sync::atomic::Ordering::Relaxed);
+        if height > current {
+            atomic.store(height, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    pub fn get_heights(&self) -> HashMap<ParticipantId, u64> {
+        self.heights
+            .iter()
+            .map(|(participant, height)| {
+                (
+                    *participant,
+                    height.load(std::sync::atomic::Ordering::Relaxed),
+                )
+            })
+            .collect()
+    }
+}

--- a/node/src/primitives.rs
+++ b/node/src/primitives.rs
@@ -64,7 +64,19 @@ pub type BatchedMessages = Vec<Vec<u8>>;
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct MpcMessage {
     pub task_id: MpcTaskId,
-    pub data: BatchedMessages,
+    pub kind: MpcMessageKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum MpcMessageKind {
+    Start(MpcStartMessage),
+    Computation(Vec<Vec<u8>>),
+    Abort(String),
+    Success,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct MpcStartMessage {
     pub participants: Vec<ParticipantId>,
 }
 
@@ -152,4 +164,19 @@ pub fn participants_from_triples(
         .filter(|p| triple1.1.participants.contains(p))
         .map(|p| p.into())
         .collect()
+}
+
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct IndexerHeightMessage {
+    pub height: u64,
+}
+
+pub struct PeerIndexerHeightMessage {
+    pub from: ParticipantId,
+    pub message: IndexerHeightMessage,
+}
+
+pub enum PeerMessage {
+    Mpc(MpcPeerMessage),
+    IndexerHeight(PeerIndexerHeightMessage),
 }

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -11,20 +11,19 @@ use tokio::sync::mpsc;
 /// describing how many messages are sent and received to each participant.
 pub async fn run_protocol<T>(
     name: &'static str,
-    mut channel: NetworkTaskChannel,
-    me: ParticipantId,
+    channel: &mut NetworkTaskChannel,
     mut protocol: impl Protocol<Output = T>,
 ) -> anyhow::Result<T> {
     let counters = Arc::new(MessageCounters::new(
         name.to_string(),
-        &channel.participants,
+        channel.participants(),
     ));
     let mut queue_senders: HashMap<ParticipantId, mpsc::UnboundedSender<BatchedMessages>> =
         HashMap::new();
     let mut queue_receivers: HashMap<ParticipantId, mpsc::UnboundedReceiver<BatchedMessages>> =
         HashMap::new();
 
-    for p in &channel.participants {
+    for p in channel.participants() {
         let (send, recv) = mpsc::unbounded_channel();
         queue_senders.insert(*p, send);
         queue_receivers.insert(*p, recv);
@@ -48,7 +47,6 @@ pub async fn run_protocol<T>(
     let sending_handle = {
         let counters = counters.clone();
         let sender = channel.sender();
-        let participants = channel.participants.clone();
         tracking::spawn_checked("send messages", async move {
             // One future for each recipient. For the same recipient it is OK to send messages
             // serially, but for multiple recipients we want them to not block each other.
@@ -58,11 +56,10 @@ pub async fn run_protocol<T>(
                 .map(move |(participant_id, mut receiver)| {
                     let sender = sender.clone();
                     let counters = counters.clone();
-                    let participants = participants.clone();
                     async move {
                         while let Some(messages) = receiver.recv().await {
                             let num_messages = messages.len();
-                            sender(participant_id, messages, participants.clone()).await?;
+                            sender.send(participant_id, messages)?;
                             counters.sent(participant_id, num_messages);
                         }
                         anyhow::Ok(())
@@ -74,7 +71,8 @@ pub async fn run_protocol<T>(
         .map_err(anyhow::Error::from)
     };
 
-    let participants = channel.participants.clone();
+    let participants = channel.participants().to_vec();
+    let my_participant_id = channel.my_participant_id();
     let computation_handle = async move {
         loop {
             let mut messages_to_send: HashMap<ParticipantId, _> = HashMap::new();
@@ -83,7 +81,7 @@ pub async fn run_protocol<T>(
                     Action::Wait => break None,
                     Action::SendMany(vec) => {
                         for participant in &participants {
-                            if participant == &me {
+                            if participant == &my_participant_id {
                                 continue;
                             }
                             messages_to_send
@@ -128,9 +126,9 @@ pub async fn run_protocol<T>(
             counters.set_receiving();
 
             let msg = channel.receive().await?;
-            counters.received(msg.from, msg.message.data.len());
+            counters.received(msg.from, msg.data.len());
 
-            for one_msg in msg.message.data {
+            for one_msg in msg.data {
                 protocol.message(msg.from.into(), one_msg);
             }
         }

--- a/node/src/protocol_version.rs
+++ b/node/src/protocol_version.rs
@@ -14,4 +14,4 @@
 /// an incompatible protocol change, we are effectively creating a new network
 /// that is separate from the old network, thus requiring only threshold number
 /// of nodes to upgrade.
-pub const MPC_PROTOCOL_VERSION: u32 = 1;
+pub const MPC_PROTOCOL_VERSION: u32 = 2;

--- a/node/src/sign.rs
+++ b/node/src/sign.rs
@@ -2,7 +2,7 @@ use crate::assets::{DistributedAssetStorage, UniqueId};
 use crate::background::InFlightGenerationTracker;
 use crate::config::PresignatureConfig;
 use crate::hkdf::{derive_public_key, derive_randomness};
-use crate::network::computation::{MpcLeaderCentricComputation, MpcLeaderCentricComputationExt};
+use crate::network::computation::MpcLeaderCentricComputation;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::{participants_from_triples, ParticipantId, PresignOutputWithParticipants};
 use crate::protocol::run_protocol;

--- a/node/src/triple.rs
+++ b/node/src/triple.rs
@@ -2,7 +2,7 @@ use crate::assets::DistributedAssetStorage;
 use crate::background::InFlightGenerationTracker;
 use crate::config::TripleConfig;
 use crate::metrics;
-use crate::network::computation::{MpcLeaderCentricComputation, MpcLeaderCentricComputationExt};
+use crate::network::computation::MpcLeaderCentricComputation;
 use crate::network::MeshNetworkClient;
 use crate::network::NetworkTaskChannel;
 use crate::primitives::{choose_random_participants, PairedTriple};
@@ -160,20 +160,19 @@ pub async fn run_background_triple_generation(
 
 #[cfg(test)]
 mod tests_many {
+    use super::{ManyTripleGenerationComputation, PairedTriple};
+    use crate::assets::UniqueId;
+    use crate::network::computation::MpcLeaderCentricComputation;
     use crate::network::testing::run_test_clients;
     use crate::network::{MeshNetworkClient, NetworkTaskChannel};
     use crate::primitives::MpcTaskId;
+    use crate::tests::TestGenerators;
     use crate::tracing::init_logging;
+    use crate::tracking;
     use futures::{stream, StreamExt};
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tokio::sync::mpsc;
-
-    use super::{ManyTripleGenerationComputation, PairedTriple};
-    use crate::assets::UniqueId;
-    use crate::network::computation::MpcLeaderCentricComputationExt;
-    use crate::tests::TestGenerators;
-    use crate::tracking;
-    use std::collections::HashMap;
 
     const NUM_PARTICIPANTS: usize = 4;
     const THRESHOLD: usize = 3;


### PR DESCRIPTION
Major changes:

* There are different kinds of network messages now:
  * MpcMessage: can be Start, Computation(data), Abort(msg), Success. See #225 for definitions. Abort is used for both Abort and LeaderAbort in the definitions.
  * IndexerHeightMessage: for syncing indexer heights, for #226 . This is exchanged and handled, but not used yet; that'll be left for a future PR focused on #226 .
* Implement leader-centric computations; make all MPC computations leader-centric:
  * If leader fails, send Abort to everyone else.
  * If follower fails, send Abort to leader.
  * For triple and presignature generation, leader wait for followers to send Success before declaring itself success.
    * TODO with next PR: Resolve #37 which is now very easy to do.
* Computations are now started explicitly with `MpcMessageKind::Start`; any messages received before receiving `Start` are buffered.
  * This supercedes the `deleted_channels` buffer before; any channels that don't receive Start will basically just be ignored.
  * `Start` carries the participant list, so now we don't have to send that along every single message.

Minor changes:
* Network messages are borsh serialized and deserialized now. No more manual serde.
* Change all network channels to unbounded channels. This makes `send` no longer async and removes any possibility of a deadlock due to channel capacities. Resolves #13 .
* Simplifies protocol interfaces so we no longer need to pass in the `participants` list and `me` into triple, presig, sig, etc. computations.
* Computations now wait for every participant to be connected, rather than doing that when `send`ing a message.

~~Minor deviation from specs from #225 :~~ (fixed)
* ~~If a computation *times out*, it does not send Abort messages to others. This is because it's beneficial for timeout to be the last layer of defense (so if it times out, everything just gets dropped forcefully), and it should be OK, because if one party times out, the other parties should also timeout at around the same time.~~