### PR TITLE
feat: add migration tool migrate keyshares from GCP to local encrypted key file

### DIFF
--- a/node/src/assets.rs
+++ b/node/src/assets.rs
@@ -822,7 +822,7 @@ mod tests {
     fn test_distributed_assets_storage() {
         let clock = FakeClock::default();
         let dir = tempfile::tempdir().unwrap();
-        let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let db = crate::db::SecretDB::new(dir.path(), [1; 16].into()).unwrap();
         let all_participants = vec![
             ParticipantId::from_raw(0),
             ParticipantId::from_raw(1),
@@ -973,7 +973,7 @@ mod tests {
     #[test]
     fn test_distributed_store_add_take_owned() {
         let dir = tempfile::tempdir().unwrap();
-        let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let db = crate::db::SecretDB::new(dir.path(), [1; 16].into()).unwrap();
         let store = super::DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
@@ -1019,7 +1019,7 @@ mod tests {
     #[test]
     fn test_distributed_store_add_owned_different_order() {
         let dir = tempfile::tempdir().unwrap();
-        let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let db = crate::db::SecretDB::new(dir.path(), [1; 16].into()).unwrap();
         let store = super::DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db.clone(),
@@ -1085,7 +1085,7 @@ mod tests {
     #[test]
     fn test_distribtued_store_add_take_unowned() {
         let dir = tempfile::tempdir().unwrap();
-        let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let db = crate::db::SecretDB::new(dir.path(), [1; 16].into()).unwrap();
         let store = super::DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
@@ -1116,7 +1116,7 @@ mod tests {
     #[test]
     fn test_distributed_store_persistence() {
         let dir = tempfile::tempdir().unwrap();
-        let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let db = crate::db::SecretDB::new(dir.path(), [1; 16].into()).unwrap();
         let myself = ParticipantId::from_raw(42);
         let store = super::DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),

--- a/node/src/keyshare/mod.rs
+++ b/node/src/keyshare/mod.rs
@@ -5,6 +5,8 @@ use cait_sith::KeygenOutput;
 use k256::{AffinePoint, Scalar, Secp256k1};
 use serde::{Deserialize, Serialize};
 
+use crate::config::AesEncryptionKey;
+
 /// The root keyshare data along with an epoch. The epoch is incremented
 /// for each key resharing. This is the format stored in the old MPC
 /// implementation, and we're keeping it the same to ease migration.
@@ -53,7 +55,7 @@ pub enum KeyshareStorageFactory {
     },
     Local {
         home_dir: std::path::PathBuf,
-        encryption_key: [u8; 16],
+        encryption_key: AesEncryptionKey,
     },
 }
 

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -5,8 +5,8 @@ use k256::{AffinePoint, Scalar, Secp256k1};
 use std::collections::HashMap;
 
 use crate::config::{
-    ConfigFile, IndexerConfig, KeygenConfig, ParticipantsConfig, PresignatureConfig, SecretsConfig,
-    SignatureConfig, SyncMode, TripleConfig, WebUIConfig,
+    AesEncryptionKey, ConfigFile, IndexerConfig, KeygenConfig, ParticipantsConfig,
+    PresignatureConfig, SecretsConfig, SignatureConfig, SyncMode, TripleConfig, WebUIConfig,
 };
 use crate::coordinator::Coordinator;
 use crate::db::SecretDB;
@@ -283,7 +283,7 @@ impl IntegrationTestSetup {
                 },
             };
             let secrets = SecretsConfig {
-                local_storage_aes_key: rand::random(),
+                local_storage_aes_key: AesEncryptionKey::from([1; 16]),
                 p2p_private_key: p2p_key,
             };
             let (indexer_api, task, currently_running_job_name) =


### PR DESCRIPTION
This PR adds an option to the main CLI program to migrate key shares from GCP to local encrypted storage. The PR resolves 
#245 .