### PR TITLE
Abstract away Signature Schema

### DIFF
--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -64,6 +64,20 @@ impl MpcConfig {
             participants,
         })
     }
+
+    /// When performing a key generation or key resharing protocol, someone has to create a channel.
+    /// Don't confuse with Leader Centric Computations.
+    pub fn is_leader_for_keygen(&self) -> bool {
+        let my_participant_id = self.my_participant_id;
+        let participant_with_lowest_id = self
+            .participants
+            .participants
+            .iter()
+            .map(|p| p.id)
+            .min()
+            .expect("Participants list should not be empty");
+        my_participant_id == participant_with_lowest_id
+    }
 }
 
 /// Config for the web UI, which is mostly for debugging and metrics.

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -22,6 +22,7 @@ mod p2p;
 mod primitives;
 mod protocol;
 mod protocol_version;
+mod providers;
 mod runtime;
 mod sign;
 mod sign_request;

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -96,9 +96,10 @@ impl MeshNetworkClient {
     /// tasks with the same MPC task ID.
     pub fn new_channel_for_task(
         &self,
-        task_id: MpcTaskId,
+        task_id: impl Into<MpcTaskId>,
         participants: Vec<ParticipantId>,
     ) -> anyhow::Result<NetworkTaskChannel> {
+        let task_id: MpcTaskId = task_id.into();
         tracing::debug!(
             target: "network",
             "[{}] Creating new channel for task {:?}",
@@ -826,7 +827,7 @@ mod tests {
     use super::{MeshNetworkClient, NetworkTaskChannel};
     use crate::assets::UniqueId;
     use crate::network::testing::run_test_clients;
-    use crate::primitives::MpcTaskId;
+    use crate::primitives::{EcdsaTaskId, MpcTaskId};
     use crate::tests::TestGenerators;
     use crate::tracking::testing::start_root_task_with_periodic_dump;
     use crate::tracking::{self, AutoAbortTaskCollection};
@@ -879,7 +880,7 @@ mod tests {
         let mut expected_results = Vec::new();
         for seed in 0..5 {
             let channel = client.new_channel_for_task(
-                MpcTaskId::ManyTriples {
+                EcdsaTaskId::ManyTriples {
                     start: UniqueId::new(participant_id, seed, 0),
                     count: 1,
                 },
@@ -953,7 +954,7 @@ mod tests {
     impl MpcLeaderCentricComputation<()> for TaskFollower {
         async fn compute(self, channel: &mut NetworkTaskChannel) -> anyhow::Result<()> {
             match channel.task_id() {
-                MpcTaskId::ManyTriples { .. } => {
+                MpcTaskId::EcdsaTaskId(EcdsaTaskId::ManyTriples { .. }) => {
                     let msg = channel.receive().await?;
                     let inner: TestTripleMessage = borsh::from_slice(&msg.data[0])?;
                     channel.sender().send(
@@ -986,7 +987,7 @@ mod fault_handling_tests {
     use super::{MeshNetworkClient, NetworkTaskChannel};
     use crate::assets::UniqueId;
     use crate::network::testing::run_test_clients;
-    use crate::primitives::{MpcTaskId, ParticipantId};
+    use crate::primitives::{EcdsaTaskId, ParticipantId};
     use crate::tests::TestGenerators;
     use crate::tracking::testing::start_root_task_with_periodic_dump;
     use near_o11y::testonly::init_integration_logger;
@@ -1055,7 +1056,7 @@ mod fault_handling_tests {
         let is_leader = client.my_participant_id().raw() == 0;
         let channel = if is_leader {
             client.new_channel_for_task(
-                MpcTaskId::ManyTriples {
+                EcdsaTaskId::ManyTriples {
                     start: UniqueId::new(me, 0, 0),
                     count: 1,
                 },

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -715,7 +715,7 @@ mod tests {
     use crate::p2p::testing::{
         generate_keypair, generate_test_p2p_configs, keypair_to_raw_ed25519_secret_key, PortSeed,
     };
-    use crate::primitives::{MpcMessage, ParticipantId, PeerMessage};
+    use crate::primitives::{EcdsaTaskId, MpcMessage, MpcTaskId, ParticipantId, PeerMessage};
     use crate::tracing::init_logging;
     use crate::tracking::testing::start_root_task_with_periodic_dump;
     use std::time::Duration;
@@ -756,7 +756,7 @@ mod tests {
 
             for i in 0..100 {
                 let msg0to1 = MpcMessage {
-                    task_id: crate::primitives::MpcTaskId::KeyResharing { new_epoch: i },
+                    task_id: MpcTaskId::EcdsaTaskId(EcdsaTaskId::KeyResharing { new_epoch: i }),
                     kind: crate::primitives::MpcMessageKind::Success,
                 };
                 sender0
@@ -773,7 +773,7 @@ mod tests {
                 assert_eq!(msg.message, msg0to1);
 
                 let msg1to0 = MpcMessage {
-                    task_id: crate::primitives::MpcTaskId::KeyResharing { new_epoch: i },
+                    task_id: MpcTaskId::EcdsaTaskId(EcdsaTaskId::KeyResharing { new_epoch: i }),
                     kind: crate::primitives::MpcMessageKind::Abort("test".to_owned()),
                 };
                 sender1

--- a/node/src/primitives.rs
+++ b/node/src/primitives.rs
@@ -87,7 +87,7 @@ pub struct MpcPeerMessage {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
-pub enum MpcTaskId {
+pub enum EcdsaTaskId {
     KeyGeneration,
     KeyResharing {
         new_epoch: u64,
@@ -104,6 +104,17 @@ pub enum MpcTaskId {
         id: SignatureId,
         presignature_id: UniqueId,
     },
+}
+
+impl From<EcdsaTaskId> for MpcTaskId {
+    fn from(val: EcdsaTaskId) -> Self {
+        MpcTaskId::EcdsaTaskId(val)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
+pub enum MpcTaskId {
+    EcdsaTaskId(EcdsaTaskId),
 }
 
 pub trait HasParticipants {

--- a/node/src/protocol_version.rs
+++ b/node/src/protocol_version.rs
@@ -14,4 +14,4 @@
 /// an incompatible protocol change, we are effectively creating a new network
 /// that is separate from the old network, thus requiring only threshold number
 /// of nodes to upgrade.
-pub const MPC_PROTOCOL_VERSION: u32 = 2;
+pub const MPC_PROTOCOL_VERSION: u32 = 3;

--- a/node/src/providers/mod.rs
+++ b/node/src/providers/mod.rs
@@ -1,0 +1,75 @@
+//! This module abstracts the Signature Schema,
+//! i.e., we might want to use ECDSA over the Secp256k1 curve, EdDSA over Ed25519, or something else.
+//! `SignatureProvider` exposes an interface for such add-ons. Alongside it, helper functions
+//! (like `RegisterMpcTask`) are exposed, which somewhat guarantees that if the code compiles,
+//! you don’t need to add anything more internally for it to work.
+//!
+//! As a reference, check the existing implementations.
+use crate::network::{MeshNetworkClient, NetworkTaskChannel};
+use crate::sign_request::SignatureId;
+use k256::Scalar;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+use crate::config::MpcConfig;
+use crate::indexer::participants::ContractResharingState;
+use crate::primitives::MpcTaskId;
+
+/// This `keyshare_id` is used for persisting a key share.
+/// The returned value should be unique across all `SignatureProviders`.
+#[allow(dead_code)] // TODO: To be fixed in #252 follow-up
+pub trait KeyshareId {
+    fn keyshare_id() -> &'static str;
+}
+
+/// The interface that defines the requirements for a signing schema to be correctly used in the code.
+#[allow(dead_code)] // TODO: To be fixed in #252 follow-up
+pub trait SignatureProvider {
+    type KeygenOutput: KeyshareId;
+    type SignatureOutput;
+
+    /// Trait bound `Into<MpcTaskId>` serves as a way to see what logic needs to be added,
+    /// when introducing new `TaskId`. Implementation of the trait should be trivial.
+    type TaskId: Into<MpcTaskId>;
+
+    /// Generates a signature.
+    /// The implementation should handle the key derivation function (KDF) if needed.
+    /// Only the leader should call this function.
+    async fn make_signature(
+        self: Arc<Self>,
+        id: SignatureId,
+    ) -> anyhow::Result<Self::SignatureOutput>;
+
+    /// Executes the key generation protocol.
+    /// Returns once key generation is complete or encounters an error.
+    /// This should only succeed if all participants are online and running this function.
+    ///
+    /// Both leaders and followers call this function.
+    ///
+    /// It drains `channel_receiver` until the required task is found, meaning these clients must not be run in parallel.
+    async fn run_key_generation_client(
+        mpc_config: MpcConfig,
+        network_client: Arc<MeshNetworkClient>,
+        channel_receiver: &mut mpsc::UnboundedReceiver<NetworkTaskChannel>,
+    ) -> anyhow::Result<Self::KeygenOutput>;
+
+    /// Executes the key resharing protocol. This can only succeed if all new participants are online.
+    /// Both leaders and followers call this function.
+    /// It drains `channel_receiver` until the required task is found, meaning these clients must not be run in parallel.
+    async fn run_key_resharing_client(
+        config: Arc<MpcConfig>,
+        client: Arc<MeshNetworkClient>,
+        state: ContractResharingState,
+        my_share: Option<Scalar>,
+        channel_receiver: mpsc::UnboundedReceiver<NetworkTaskChannel>,
+    ) -> anyhow::Result<Self::KeygenOutput>;
+
+    /// Expected to be called in a common loop that handles received channels and redirects them
+    /// to the respective `SignatureProvider`.
+    /// This function is called during the "normal MPC run",
+    /// i.e., it should fail if it receives messages from the `KeyGeneration` or `KeyResharing` stage.
+    async fn process_channel(self: Arc<Self>, channel: NetworkTaskChannel) -> anyhow::Result<()>;
+
+    /// Spawns any auxiliary logic that performs pre-computation (typically meant to optimize signature delay).
+    async fn spawn_background_tasks(self: Arc<Self>) -> anyhow::Result<()>;
+}

--- a/node/src/sign.rs
+++ b/node/src/sign.rs
@@ -4,7 +4,9 @@ use crate::config::PresignatureConfig;
 use crate::hkdf::{derive_public_key, derive_randomness};
 use crate::network::computation::MpcLeaderCentricComputation;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
-use crate::primitives::{participants_from_triples, ParticipantId, PresignOutputWithParticipants};
+use crate::primitives::{
+    participants_from_triples, EcdsaTaskId, ParticipantId, PresignOutputWithParticipants,
+};
 use crate::protocol::run_protocol;
 use crate::tracking::AutoAbortTaskCollection;
 use crate::triple::TripleStorage;
@@ -252,7 +254,7 @@ pub async fn run_background_presignature_generation(
             let (paired_triple_id, (triple0, triple1)) = triple_store.take_owned().await;
             progress_tracker.set_waiting_for_triples(false);
             let participants = participants_from_triples(&triple0, &triple1);
-            let task_id = crate::primitives::MpcTaskId::Presignature {
+            let task_id = EcdsaTaskId::Presignature {
                 id,
                 paired_triple_id,
             };


### PR DESCRIPTION
This PR aims to create abstraction over signature schema.
Most of the changes are refactoring:
* Move existing implementations of `cait-sith`-related code into its `SignatureProvider` (namely, `triple.rs`, `presign.rs`, part of `hkdf.rs` and so on). 

The new logic introduced:
* `MpcClient` made responsible for distributing `MpcTaskId` to each `SignatureProvider`
* `KeyshareStorage` made compatible with any type of keyshare
* `KeyGeneration` and `KeyResharing` semantics does not do keyshare persisting now. This was lifted up into `Coordinator.rs` logic. The reason is because at the moment it's not clear how to handle `epoch` and introduction of new keys. More on that below[1].

What this PR should do, but doesn't (will be addressed in the future PRs):
* Different Database Schemas for each signature provider (and thus flushing policy)
* GCP implementation or removal of such (at the moment I didn't bother with adding changes for it)
* Further step back from `cait-sith` structs and types, such as `Scalar`, which for example used to denote `tweak`, which essentially needs to be just a `[u8; 32]`.


[1]
* What should we do when a set of node wants to generate a keyshare of a new signature provider? 
* Should we use an `epoch = 0` for a new share or use the existing one?
* How do we guarantee atomicity when performing key-resharing? Do we even need this property? What if some node failed to write its share, while others succeeded?   