### PR TITLE
Simplify Dockerfile, and add CI for devnet directory.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,17 @@ jobs:
           RUSTFLAGS="-D warnings" \
           cargo clippy --all-features --all-targets --locked
 
+          cd devnet
+          CARGO_TARGET_DIR="target/clippy" \
+          RUSTFLAGS="-D warnings" \
+          cargo clippy --all-features --all-targets --locked
+
       - name: Run Cargo fmt
-        run: cargo fmt -- --check
+        run: |
+          cargo fmt -- --check
+
+          cd devnet
+          cargo fmt -- --check
           
       - name: Install cargo-nextest
         run: cargo install cargo-nextest

--- a/deployment/Dockerfile-gcp
+++ b/deployment/Dockerfile-gcp
@@ -1,31 +1,13 @@
-FROM lukemathwalker/cargo-chef:latest AS chef
+FROM rust:latest AS builder
 RUN apt-get update -y && apt-get install -y --no-install-recommends clang  # needed for rocksdb
+
 WORKDIR /app
-
-FROM chef AS planner
-
 COPY node node
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml
-COPY .git .git
-COPY .gitmodules .gitmodules
+COPY rust-toolchain.toml rust-toolchain.toml
 
-RUN git submodule update --init --recursive
-RUN cargo chef prepare --recipe-path /app/recipe.json
-
-FROM chef AS builder
-COPY --from=planner /app/recipe.json recipe.json
-COPY .git .git
-COPY .gitmodules .gitmodules
-
-RUN git submodule update --init --recursive
-RUN cargo chef cook --release --recipe-path recipe.json
-
-COPY node node
-COPY Cargo.lock Cargo.lock
-COPY Cargo.toml Cargo.toml
-
-RUN cargo build --release
+RUN cargo build --locked --release
 
 FROM google/cloud-sdk:debian_component_based AS runtime
 RUN apt-get update -y \

--- a/devnet/Cargo.lock
+++ b/devnet/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-shared"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/devnet/src/main.rs
+++ b/devnet/src/main.rs
@@ -7,10 +7,10 @@ mod constants;
 mod devnet;
 mod funding;
 mod loadtest;
-mod rpc;
-mod types;
 mod mpc;
+mod rpc;
 mod terraform;
+mod types;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
The dockerfile used to use cargo-chef for incremental compilation. But now, our docker workflow doesn't really care about incremental compilation anymore because they are run on github actions anyway. Cargo-chef breaks on kevin's latest PR, for reasons that isn't worthwhile investigating. So I'm removing that and using standard rust compilation.

Also add rust-toolchain.toml which we should be having, add --locked to ensure versioning, and remove the need for .git. We don't need any of the submodules for compiling mpc-node.

Also while I'm at it, add devnet to the CI - otherwise some changes may cause Cargo.lock to change in that directory and we don't end up catching that.