### PR TITLE
Implement multi-domain contract-coordinated key storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "1.0.0"
+version = "2.0.0-alpha"
 dependencies = [
  "actix",
  "aes-gcm",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-node"
-version = "1.0.0"
+version = "2.0.0-alpha" # DO NOT RELEASE
 edition = "2021"
 
 [dependencies]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -526,7 +526,6 @@ mod tests {
             result.is_err(),
             "Import command with lower epoch should fail"
         );
-        assert!(result.unwrap_err().to_string().contains("Refusing to overwrite existing keyshare of epoch 2 with new keyshare of older or same epoch 1"));
     }
 
     #[tokio::test]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -6,9 +6,12 @@ use crate::config::{ConfigFile, IndexerConfig};
 use crate::coordinator::Coordinator;
 use crate::db::SecretDB;
 use crate::indexer::{real::spawn_real_indexer, IndexerAPI};
-use crate::keyshare::{
-    local::LocalKeyshareStorage, KeyshareStorage, KeyshareStorageFactory, RootKeyshareData,
+use crate::keyshare::compat::legacy_ecdsa_key_from_keyshares;
+use crate::keyshare::local::LocalPermanentKeyStorageBackend;
+use crate::keyshare::permanent::{
+    LegacyRootKeyshareData, PermanentKeyStorage, PermanentKeyStorageBackend,
 };
+use crate::keyshare::{GcpPermanentKeyStorageConfig, KeyStorageConfig};
 use crate::p2p::testing::{generate_test_p2p_configs, PortSeed};
 use crate::tracking::{self, start_root_task};
 use crate::web::start_web_server;
@@ -189,19 +192,22 @@ impl StartCmd {
 
         let secret_db = SecretDB::new(&home_dir, secrets.local_storage_aes_key)?;
 
-        let keyshare_storage_factory = if let Some(secret_id) = gcp_keyshare_secret_id {
-            let project_id = gcp_project_id.ok_or_else(|| {
-                anyhow::anyhow!("GCP_PROJECT_ID must be specified to use GCP_KEYSHARE_SECRET_ID")
-            })?;
-            KeyshareStorageFactory::Gcp {
-                project_id,
-                secret_id,
-            }
-        } else {
-            KeyshareStorageFactory::Local {
-                home_dir: home_dir.clone(),
-                encryption_key: secrets.local_storage_aes_key,
-            }
+        let key_storage_config = KeyStorageConfig {
+            home_dir: home_dir.clone(),
+            local_encryption_key: secrets.local_storage_aes_key,
+            gcp: if let Some(secret_id) = gcp_keyshare_secret_id {
+                let project_id = gcp_project_id.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "GCP_PROJECT_ID must be specified to use GCP_KEYSHARE_SECRET_ID"
+                    )
+                })?;
+                Some(GcpPermanentKeyStorageConfig {
+                    project_id,
+                    secret_id,
+                })
+            } else {
+                None
+            },
         };
 
         let coordinator = Coordinator {
@@ -209,7 +215,7 @@ impl StartCmd {
             config_file: config,
             secrets,
             secret_db,
-            keyshare_storage_factory,
+            key_storage_config,
             indexer: indexer_api,
             currently_running_job_name: Arc::new(Mutex::new(String::new())),
             signature_debug_request_sender,
@@ -345,7 +351,7 @@ impl ImportKeyshareCmd {
             })?;
 
         // Parse the keyshare JSON
-        let keyshare: RootKeyshareData = serde_json::from_str(&self.keyshare_json)
+        let keyshare: LegacyRootKeyshareData = serde_json::from_str(&self.keyshare_json)
             .map_err(|e| anyhow::anyhow!("Failed to parse keyshare JSON: {}", e))?;
 
         println!("Parsed keyshare for epoch {}", keyshare.epoch);
@@ -360,22 +366,18 @@ impl ImportKeyshareCmd {
             })?;
         }
 
-        let storage = LocalKeyshareStorage::new(home_dir.clone(), encryption_key_bytes);
+        let storage =
+            LocalPermanentKeyStorageBackend::new(home_dir.clone(), encryption_key_bytes).await?;
 
         // Check for existing keyshare
-        if let Some(existing) = storage.load().await? {
-            println!("Found existing keyshare with epoch {}", existing.epoch);
-            if existing.epoch >= keyshare.epoch {
-                return Err(anyhow::anyhow!(
-                    "Refusing to overwrite existing keyshare of epoch {} with new keyshare of older or same epoch {}",
-                    existing.epoch,
-                    keyshare.epoch
-                ));
-            }
+        if storage.load().await?.is_some() {
+            anyhow::bail!("Refusing to overwrite existing local keyshare");
         }
 
         // Store the keyshare
-        storage.store(&keyshare).await?;
+        storage
+            .store(&serde_json::to_vec(&keyshare)?, "imported")
+            .await?;
         println!("Successfully imported keyshare to {}", home_dir.display());
 
         Ok(())
@@ -403,13 +405,17 @@ impl ExportKeyshareCmd {
             ));
         }
 
-        let storage = LocalKeyshareStorage::new(home_dir.clone(), encryption_key_bytes);
+        let storage = PermanentKeyStorage::new(Box::new(
+            LocalPermanentKeyStorageBackend::new(home_dir.clone(), encryption_key_bytes).await?,
+        ))
+        .await?;
 
         // Load the keyshare
         let keyshare = storage
             .load()
             .await?
             .ok_or_else(|| anyhow::anyhow!("No keyshare found in {}", home_dir.display()))?;
+        let keyshare = legacy_ecdsa_key_from_keyshares(&keyshare.keyshares)?;
 
         // Print the keyshare to console
         let json = serde_json::to_string_pretty(&keyshare)
@@ -432,11 +438,11 @@ mod tests {
     use tempfile::TempDir;
 
     // Mock keyshare data for testing
-    fn create_test_keyshare() -> RootKeyshareData {
+    fn create_test_keyshare() -> LegacyRootKeyshareData {
         // Create a dummy private key - this is only for testing
         let private_share = Scalar::ONE;
         let public_key = AffinePoint::default();
-        RootKeyshareData {
+        LegacyRootKeyshareData {
             epoch: 1,
             private_share,
             public_key,

--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -7,7 +7,8 @@ use crate::indexer::participants::{
 };
 use crate::indexer::types::{ChainSendTransactionRequest, ChainVotePkArgs, ChainVoteResharedArgs};
 use crate::indexer::IndexerAPI;
-use crate::keyshare::{KeyshareStorage, KeyshareStorageFactory, RootKeyshareData};
+use crate::keyshare::permanent::LegacyRootKeyshareData;
+use crate::keyshare::{KeyShare, KeyStorageConfig, KeyshareStorage};
 use crate::metrics;
 use crate::mpc_client::MpcClient;
 use crate::network::{run_network_client, MeshNetworkTransportSender};
@@ -19,6 +20,7 @@ use crate::tracking::{self};
 use crate::web::SignatureDebugRequest;
 use futures::future::BoxFuture;
 use futures::FutureExt;
+use mpc_contract::primitives::key_state::EpochId;
 use near_time::{Clock, Duration};
 use std::future::Future;
 use std::sync::{Arc, Mutex};
@@ -36,8 +38,8 @@ pub struct Coordinator {
 
     /// Storage for triples, presignatures, signing requests.
     pub secret_db: Arc<SecretDB>,
-    /// Storage for keyshare.
-    pub keyshare_storage_factory: KeyshareStorageFactory,
+    /// Storage config for keyshares.
+    pub key_storage_config: KeyStorageConfig,
 
     /// For interaction with the indexer.
     pub indexer: IndexerAPI,
@@ -111,7 +113,7 @@ impl Coordinator {
                             Self::run_initialization(
                                 self.secrets.clone(),
                                 self.config_file.clone(),
-                                self.keyshare_storage_factory.create().await?,
+                                self.key_storage_config.create().await?,
                                 state.clone(),
                                 self.indexer.txn_sender.clone(),
                             ),
@@ -144,7 +146,7 @@ impl Coordinator {
                                 self.secret_db.clone(),
                                 self.secrets.clone(),
                                 self.config_file.clone(),
-                                self.keyshare_storage_factory.create().await?,
+                                self.key_storage_config.create().await?,
                                 state.clone(),
                                 self.indexer.txn_sender.clone(),
                                 self.indexer
@@ -173,7 +175,7 @@ impl Coordinator {
                                 self.secret_db.clone(),
                                 self.secrets.clone(),
                                 self.config_file.clone(),
-                                self.keyshare_storage_factory.create().await?,
+                                self.key_storage_config.create().await?,
                                 state.clone(),
                                 self.indexer.txn_sender.clone(),
                                 // here, pass self.indexer.reshare_instance_receiver
@@ -275,38 +277,15 @@ impl Coordinator {
     async fn run_initialization(
         secrets: SecretsConfig,
         config_file: ConfigFile,
-        keyshare_storage: Box<dyn KeyshareStorage>,
+        keyshare_storage: KeyshareStorage,
         contract_state: ContractInitializingState,
         chain_txn_sender: mpsc::Sender<ChainSendTransactionRequest>,
     ) -> anyhow::Result<MpcJobResult> {
-        let existing_key = keyshare_storage.load().await?;
-        if let Some(existing_key) = existing_key {
-            if existing_key.epoch != 0 {
-                tracing::error!(
-                    "Contract is in initialization state. We already have a keyshare, but its epoch is not zero. Refusing to participate in initialization"
-                );
-                // This is an error situation; we can't recover from it so we just halt.
-                return Ok(MpcJobResult::HaltUntilInterrupted);
-            }
-
-            let my_public_key = affine_point_to_public_key(existing_key.public_key)?;
-            if let Some(votes) = contract_state.pk_votes.get(&my_public_key) {
-                if votes.contains(&config_file.my_near_account_id) {
-                    tracing::info!("Initialization: we already voted for our public key; waiting for public key consensus");
-                    // Wait indefinitely. We will be terminated when config changes, or when we timeout.
-                    return Ok(MpcJobResult::HaltUntilInterrupted);
-                }
-            }
-
-            tracing::info!("Contract is in initialization state. We have our keyshare. Sending vote_pk to vote for our public key");
-
-            chain_txn_sender
-                .send(ChainSendTransactionRequest::VotePk(ChainVotePkArgs {
-                    public_key: my_public_key,
-                }))
-                .await?;
-
-            // Like above, just wait.
+        if let Err(e) = keyshare_storage
+            .ensure_can_generate_key(EpochId::new(0), &[])
+            .await
+        {
+            tracing::error!("Cannot participate in key generation: {:?}", e);
             return Ok(MpcJobResult::HaltUntilInterrupted);
         }
 
@@ -346,11 +325,21 @@ impl Coordinator {
         .await?;
 
         keyshare_storage
-            .store(&RootKeyshareData::new(0, key.clone()))
+            .store_key(KeyShare::from_legacy(&LegacyRootKeyshareData {
+                epoch: 0,
+                private_share: key.private_share,
+                public_key: key.public_key,
+            }))
+            .await?;
+        let my_public_key = affine_point_to_public_key(key.public_key)?;
+        chain_txn_sender
+            .send(ChainSendTransactionRequest::VotePk(ChainVotePkArgs {
+                public_key: my_public_key,
+            }))
             .await?;
 
-        tracing::info!("Key generation complete");
-        anyhow::Ok(MpcJobResult::Done)
+        // Just halt and wait for the running state.
+        return Ok(MpcJobResult::HaltUntilInterrupted);
     }
 
     /// Entry point to handle the Running state of the contract.
@@ -362,7 +351,7 @@ impl Coordinator {
         secret_db: Arc<SecretDB>,
         secrets: SecretsConfig,
         config_file: ConfigFile,
-        keyshare_storage: Box<dyn KeyshareStorage>,
+        keyshare_storage: KeyshareStorage,
         contract_state: ContractRunningState,
         chain_txn_sender: mpsc::Sender<ChainSendTransactionRequest>,
         block_update_receiver: tokio::sync::OwnedMutexGuard<
@@ -379,15 +368,15 @@ impl Coordinator {
             return Ok(MpcJobResult::HaltUntilInterrupted);
         };
 
-        let keyshare = keyshare_storage.load().await?;
-        let keyshare = match keyshare {
-            Some(keyshare) if keyshare.epoch == contract_state.epoch => keyshare,
-            _ => {
-                // This case can happen if a participant is misconfigured or lost its keyshare.
-                // We can't do anything. The only way to recover if the keyshare is truly lost
-                // is to leave and rejoin the network.
+        let keyshare = match keyshare_storage
+            .compat_load_legacy_keyshare(contract_state.epoch, contract_state.root_public_key)
+            .await
+        {
+            Ok(keyshare) => keyshare,
+            Err(e) => {
                 tracing::error!(
-                    "This node is a participant in the current epoch but is missing a keyshare."
+                    "Failed to load keyshare: {:?}; doing nothing until contract state change",
+                    e
                 );
                 return Ok(MpcJobResult::HaltUntilInterrupted);
             }
@@ -442,7 +431,7 @@ impl Coordinator {
         secret_db: Arc<SecretDB>,
         secrets: SecretsConfig,
         config_file: ConfigFile,
-        keyshare_storage: Box<dyn KeyshareStorage>,
+        keyshare_storage: KeyshareStorage,
         contract_state: ContractResharingState,
         chain_txn_sender: mpsc::Sender<ChainSendTransactionRequest>,
         // reshare_instance_receiver
@@ -461,58 +450,36 @@ impl Coordinator {
             .iter()
             .any(|p| p.near_account_id == config_file.my_near_account_id);
 
-        let existing_keyshare = match keyshare_storage.load().await? {
-            Some(existing_keyshare) => {
-                // only enter this if the full key event id matches.
-                if existing_keyshare.epoch == contract_state.old_epoch + 1 {
-                    // check key id: a mismatch should (theoretically) never happen.
-                    if contract_state
-                        .finished_votes
-                        .contains(&config_file.my_near_account_id)
-                    {
-                        tracing::info!(
-                            "We already performed key resharing for epoch {} and already performed vote_reshared; waiting for contract state to transition into Running",
-                            contract_state.old_epoch + 1);
-                    } else {
-                        tracing::info!(
-                            "We already performed key resharing for epoch {}; sending vote_reshared.",
-                            contract_state.old_epoch + 1
-                        );
-                        chain_txn_sender
-                            .send(ChainSendTransactionRequest::VoteReshared(
-                                ChainVoteResharedArgs {
-                                    epoch: contract_state.old_epoch + 1,
-                                },
-                            ))
-                            .await?; // adjust
-                        tracing::info!("Sent vote_reshared txn; waiting for contract state to transition into Running");
-                    }
+        if let Err(e) = keyshare_storage
+            .ensure_can_reshare_key(EpochId::new(contract_state.old_epoch + 1), &[])
+            .await
+        {
+            tracing::error!("Cannot participate in key resharing: {:?}", e);
+            return Ok(MpcJobResult::HaltUntilInterrupted);
+        }
+
+        let existing_keyshare = if was_participant_last_epoch {
+            let existing_keyshare = match keyshare_storage
+                .compat_load_legacy_keyshare(
+                    contract_state.old_epoch,
+                    contract_state.public_key.clone(),
+                )
+                .await
+            {
+                Ok(keyshare) => keyshare,
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to load keyshare for epoch {}: {:?}; doing nothing until contract state change",
+                        contract_state.old_epoch,
+                        e
+                    );
                     return Ok(MpcJobResult::HaltUntilInterrupted);
                 }
-                if was_participant_last_epoch {
-                    anyhow::ensure!(
-                        existing_keyshare.epoch == contract_state.old_epoch,
-                        "We were a participant last epoch, but we somehow have a key of epoch #{}",
-                        existing_keyshare.epoch
-                    );
-                    Some(existing_keyshare)
-                } else {
-                    anyhow::ensure!(
-                        existing_keyshare.epoch < contract_state.old_epoch,
-                        "We were not a participant last epoch, but we somehow have a key of epoch #{}",
-                        existing_keyshare.epoch
-                    );
-                    None
-                }
-            }
-            None => {
-                if was_participant_last_epoch {
-                    anyhow::bail!("We were a participant last epoch, but we don't have a keyshare");
-                }
-                None
-            }
+            };
+            Some(existing_keyshare)
+        } else {
+            None
         };
-
         tracking::set_progress(&format!(
             "Resharing for epoch {} as participant {}",
             contract_state.old_epoch + 1,
@@ -551,18 +518,26 @@ impl Coordinator {
         )
         .await?;
         keyshare_storage
-            .store(&RootKeyshareData::new(
-                contract_state.old_epoch + 1,
-                new_keygen_output,
-            ))
+            .store_key(KeyShare::from_legacy(&LegacyRootKeyshareData {
+                epoch: contract_state.old_epoch + 1,
+                private_share: new_keygen_output.private_share,
+                public_key: new_keygen_output.public_key,
+            }))
             .await?;
 
         tracing::info!("Key resharing complete; will call vote_reshared next");
-        // Exit; we'll immediately re-enter the same function and send vote_reshared.
-        // maybe send vote_instance_complete() here, before exiting.
-        //
 
-        // leader needs to observe the contract state here.
+        chain_txn_sender
+            .send(ChainSendTransactionRequest::VoteReshared(
+                ChainVoteResharedArgs {
+                    epoch: contract_state.old_epoch + 1,
+                },
+            ))
+            .await?; // adjust
+        tracing::info!(
+            "Sent vote_reshared txn; waiting for contract state to transition into Running"
+        );
+
         Ok(MpcJobResult::Done)
     }
 }

--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -8,7 +8,7 @@ use crate::indexer::participants::{
 use crate::indexer::types::{ChainSendTransactionRequest, ChainVotePkArgs, ChainVoteResharedArgs};
 use crate::indexer::IndexerAPI;
 use crate::keyshare::permanent::LegacyRootKeyshareData;
-use crate::keyshare::{KeyShare, KeyStorageConfig, KeyshareStorage};
+use crate::keyshare::{KeyStorageConfig, Keyshare, KeyshareStorage};
 use crate::metrics;
 use crate::mpc_client::MpcClient;
 use crate::network::{run_network_client, MeshNetworkTransportSender};
@@ -325,7 +325,7 @@ impl Coordinator {
         .await?;
 
         keyshare_storage
-            .store_key(KeyShare::from_legacy(&LegacyRootKeyshareData {
+            .store_key(Keyshare::from_legacy(&LegacyRootKeyshareData {
                 epoch: 0,
                 private_share: key.private_share,
                 public_key: key.public_key,
@@ -339,7 +339,7 @@ impl Coordinator {
             .await?;
 
         // Just halt and wait for the running state.
-        return Ok(MpcJobResult::HaltUntilInterrupted);
+        Ok(MpcJobResult::HaltUntilInterrupted)
     }
 
     /// Entry point to handle the Running state of the contract.
@@ -518,7 +518,7 @@ impl Coordinator {
         )
         .await?;
         keyshare_storage
-            .store_key(KeyShare::from_legacy(&LegacyRootKeyshareData {
+            .store_key(Keyshare::from_legacy(&LegacyRootKeyshareData {
                 epoch: contract_state.old_epoch + 1,
                 private_share: new_keygen_output.private_share,
                 public_key: new_keygen_output.public_key,

--- a/node/src/keyshare/compat.rs
+++ b/node/src/keyshare/compat.rs
@@ -1,0 +1,64 @@
+use super::permanent::LegacyRootKeyshareData;
+use super::{KeyShare, KeyShareData, KeyshareStorage, Secp256k1Data};
+use mpc_contract::primitives::domain::DomainId;
+use mpc_contract::primitives::key_state::{AttemptId, EpochId, KeyEventId, KeyForDomain, Keyset};
+
+/// For compatibility while we perform the refactoring.
+/// Converts the new format keyshares array to the old format.
+pub fn legacy_ecdsa_key_from_keyshares(
+    keyshares: &[KeyShare],
+) -> anyhow::Result<LegacyRootKeyshareData> {
+    if keyshares.len() != 1 {
+        anyhow::bail!("Expected exactly one keyshare, got {}", keyshares.len());
+    }
+    let keyshare = &keyshares[0];
+    if keyshare.key_id.domain_id != DomainId::legacy_ecdsa_id() {
+        anyhow::bail!(
+            "Expected keyshare for legacy ECDSA domain, got {:?}",
+            keyshare.key_id.domain_id
+        );
+    }
+    let secp256k1_data = match &keyshare.data {
+        KeyShareData::Secp256k1(secp256k1_data) => secp256k1_data,
+    };
+    Ok(LegacyRootKeyshareData {
+        epoch: keyshare.key_id.epoch_id.get(),
+        private_share: secp256k1_data.private_share,
+        public_key: secp256k1_data.public_key,
+    })
+}
+
+impl KeyshareStorage {
+    pub async fn compat_load_legacy_keyshare(
+        &self,
+        epoch_id: u64,
+        public_key: near_crypto::PublicKey,
+    ) -> anyhow::Result<LegacyRootKeyshareData> {
+        let keyset = Keyset {
+            epoch_id: EpochId::new(epoch_id),
+            domains: vec![KeyForDomain {
+                domain_id: DomainId::legacy_ecdsa_id(),
+                key: public_key.to_string().parse()?,
+                attempt: AttemptId::legacy_attempt_id(),
+            }],
+        };
+        let keyshares = self.load_keyset(&keyset).await?;
+        legacy_ecdsa_key_from_keyshares(&keyshares)
+    }
+}
+
+impl KeyShare {
+    pub fn from_legacy(legacy: &LegacyRootKeyshareData) -> Self {
+        Self {
+            key_id: KeyEventId::new(
+                EpochId::new(legacy.epoch),
+                DomainId::legacy_ecdsa_id(),
+                AttemptId::legacy_attempt_id(),
+            ),
+            data: KeyShareData::Secp256k1(Secp256k1Data {
+                private_share: legacy.private_share,
+                public_key: legacy.public_key,
+            }),
+        }
+    }
+}

--- a/node/src/keyshare/compat.rs
+++ b/node/src/keyshare/compat.rs
@@ -1,5 +1,6 @@
 use super::permanent::LegacyRootKeyshareData;
-use super::{Keyshare, KeyshareData, KeyshareStorage, Secp256k1KeyshareData};
+use super::{Keyshare, KeyshareData, KeyshareStorage};
+use cait_sith::KeygenOutput;
 use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::key_state::{AttemptId, EpochId, KeyEventId, KeyForDomain, Keyset};
 
@@ -56,7 +57,7 @@ impl Keyshare {
                 DomainId::legacy_ecdsa_id(),
                 AttemptId::legacy_attempt_id(),
             ),
-            data: KeyshareData::Secp256k1(Secp256k1KeyshareData {
+            data: KeyshareData::Secp256k1(KeygenOutput {
                 private_share: legacy.private_share,
                 public_key: legacy.public_key,
             }),

--- a/node/src/keyshare/gcp.rs
+++ b/node/src/keyshare/gcp.rs
@@ -1,4 +1,4 @@
-use super::{KeyshareStorage, RootKeyshareData};
+use super::permanent::PermanentKeyStorageBackend;
 use anyhow::Context;
 use gcloud_sdk::google::cloud::secretmanager::v1::secret_manager_service_client::SecretManagerServiceClient;
 use gcloud_sdk::google::cloud::secretmanager::v1::secret_version::State;
@@ -9,13 +9,13 @@ use gcloud_sdk::proto_ext::secretmanager::SecretPayload;
 use gcloud_sdk::{GoogleApi, GoogleAuthMiddleware, SecretValue};
 
 /// Keyshare storage that loads and stores the key from Google Secret Manager.
-pub struct GcpKeyshareStorage {
+pub struct GcpPermanentKeyStorageBackend {
     secrets_client: GoogleApi<SecretManagerServiceClient<GoogleAuthMiddleware>>,
     project_id: String,
     secret_id: String,
 }
 
-impl GcpKeyshareStorage {
+impl GcpPermanentKeyStorageBackend {
     pub async fn new(project_id: String, secret_id: String) -> anyhow::Result<Self> {
         let secrets_client = GoogleApi::from_function(
             SecretManagerServiceClient::new,
@@ -34,8 +34,8 @@ impl GcpKeyshareStorage {
 }
 
 #[async_trait::async_trait]
-impl KeyshareStorage for GcpKeyshareStorage {
-    async fn load(&self) -> anyhow::Result<Option<RootKeyshareData>> {
+impl PermanentKeyStorageBackend for GcpPermanentKeyStorageBackend {
+    async fn load(&self) -> anyhow::Result<Option<Vec<u8>>> {
         let secret_name = format!("projects/{}/secrets/{}", self.project_id, self.secret_id);
         let versions = self
             .secrets_client
@@ -67,30 +67,17 @@ impl KeyshareStorage for GcpKeyshareStorage {
             .payload
             .ok_or_else(|| anyhow::anyhow!("Secret version has no payload"))?;
 
-        let keyshare: RootKeyshareData = serde_json::from_slice(secret.data.as_sensitive_bytes())
-            .context("Failed to parse keygen")?;
-        Ok(Some(keyshare))
+        Ok(Some(secret.data.as_sensitive_bytes().to_vec()))
     }
 
-    async fn store(&self, root_keyshare: &RootKeyshareData) -> anyhow::Result<()> {
-        let existing = self.load().await.context("Checking existing keyshare")?;
-        if let Some(existing) = existing {
-            if existing.epoch >= root_keyshare.epoch {
-                return Err(anyhow::anyhow!(
-                    "Refusing to overwrite existing keyshare of epoch {} with new keyshare of older epoch {}",
-                    existing.epoch,
-                    root_keyshare.epoch,
-                ));
-            }
-        }
+    async fn store(&self, data: &[u8], _identifier: &str) -> anyhow::Result<()> {
         let secret_name = format!("projects/{}/secrets/{}", self.project_id, self.secret_id);
-        let data = serde_json::to_vec(&root_keyshare).context("Failed to serialize keygen")?;
         self.secrets_client
             .get()
             .add_secret_version(AddSecretVersionRequest {
                 parent: secret_name,
                 payload: Some(SecretPayload {
-                    data: SecretValue::new(data),
+                    data: SecretValue::new(data.to_vec()),
                     ..Default::default()
                 }),
             })

--- a/node/src/keyshare/mod.rs
+++ b/node/src/keyshare/mod.rs
@@ -3,25 +3,82 @@ pub mod local;
 
 use cait_sith::KeygenOutput;
 use k256::{AffinePoint, Scalar, Secp256k1};
+use mpc_contract::primitives::{
+    domain::DomainId,
+    key_state::{AttemptId, EpochId, KeyEventId},
+};
 use serde::{Deserialize, Serialize};
 
-/// The root keyshare data along with an epoch. The epoch is incremented
-/// for each key resharing. This is the format stored in the old MPC
-/// implementation, and we're keeping it the same to ease migration.
+use crate::indexer::participants::ContractKeyset;
 #[derive(Clone, Serialize, Deserialize)]
-pub struct RootKeyshareData {
-    pub epoch: u64,
+pub struct Secp256k1Data {
     pub private_share: Scalar,
     pub public_key: AffinePoint,
 }
+#[derive(Clone, Serialize, Deserialize)]
+pub enum KeyShareData {
+    Secp256k1(Secp256k1Data),
+}
 
-impl RootKeyshareData {
+// The keystore is a mess right now, because changes will depend on PR #278.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct KeyShare {
+    pub key_id: KeyEventId,
+    pub data: KeyShareData,
+}
+impl KeyShare {
+    //pub fn domain_id(&self) -> DomainId {
+    //    self.key_id.domain_id
+    //}
+    pub fn epoch_id(&self) -> EpochId {
+        self.key_id.epoch_id
+    }
+    pub fn attempt_id(&self) -> AttemptId {
+        self.key_id.attempt_id
+    }
     pub fn keygen_output(&self) -> KeygenOutput<Secp256k1> {
         KeygenOutput {
             private_share: self.private_share,
             public_key: self.public_key,
         }
     }
+    pub fn new(key_id: KeyEventId, keygen_output: KeygenOutput<Secp256k1>) -> Self {
+        Self {
+            key_id,
+            private_share: keygen_output.private_share,
+            public_key: keygen_output.public_key,
+        }
+    }
+}
+pub fn migrate_root_key_share_data(root_keyshare: RootKeyshareData) -> KeyShare {
+    KeyShare {
+        key_id: KeyEventId::new(
+            EpochId::new(root_keyshare.epoch),
+            DomainId::legacy_ecdsa_id(),
+            AttemptId::legacy_attempt_id(),
+        ),
+        private_share: root_keyshare.private_share,
+        public_key: root_keyshare.public_key,
+    }
+}
+/// The root keyshare data along with an epoch. The epoch is incremented
+/// for each key resharing. This is the format stored in the old MPC
+/// implementation, and we're keeping it the same to ease migration.
+/// Deprecated
+#[derive(Clone, Serialize, Deserialize)]
+pub struct RootKeyshareData {
+    pub epoch: u64,
+    pub private_share: Scalar,
+    pub public_key: AffinePoint,
+}
+#[cfg(test)]
+impl RootKeyshareData {
+    //pub fn keygen_output(&self) -> KeygenOutput<Secp256k1> {
+    //    KeygenOutput {
+    //        private_share: self.private_share,
+    //        public_key: self.public_key,
+    //    }
+    //}
 
     pub fn new(epoch: u64, keygen_output: KeygenOutput<Secp256k1>) -> Self {
         Self {
@@ -38,11 +95,14 @@ pub trait KeyshareStorage: Send {
     /// Loads the most recent root keyshare data. Returns an error if the data
     /// cannot be read. Returns Ok(None) if the data does not exist (i.e. we've
     /// never participated successfully in a key generation).
-    async fn load(&self) -> anyhow::Result<Option<RootKeyshareData>>;
+    /// todo: add epoch_id as argument?
+    async fn load(&self) -> anyhow::Result<Option<KeyShare>>;
 
     /// Stores the most recent root keyshare data. This can only succeed if the
     /// keyshare didn't exist before or if the new data has a higher epoch.
-    async fn store(&self, data: &RootKeyshareData) -> anyhow::Result<()>;
+    async fn store(&self, key_share: &KeyShare) -> anyhow::Result<()>;
+
+    async fn load_keyset(&self, keyset: &ContractKeyset) -> anyhow::Result<Vec<KeyShare>>;
 }
 
 /// Factory to construct a KeyshareStorage implementation.
@@ -76,5 +136,33 @@ impl KeyshareStorageFactory {
                 Ok(Box::new(storage))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mpc_contract::primitives::key_state::AttemptId;
+    use rand::Rng;
+
+    use crate::{
+        keyshare::{migrate_root_key_share_data, RootKeyshareData},
+        tests::TestGenerators,
+    };
+
+    #[test]
+    fn test_migration() {
+        let generated_key = TestGenerators::new(2, 2)
+            .make_keygens()
+            .into_iter()
+            .next()
+            .unwrap()
+            .1;
+        let epoch_id = rand::thread_rng().gen();
+        let expected = RootKeyshareData::new(epoch_id, generated_key.clone());
+        let migrated = migrate_root_key_share_data(expected.clone());
+        assert_eq!(migrated.attempt_id(), AttemptId::legacy_attempt_id());
+        assert_eq!(migrated.epoch_id().get(), epoch_id);
+        assert_eq!(migrated.private_share, expected.private_share);
+        assert_eq!(migrated.public_key, expected.public_key);
     }
 }

--- a/node/src/keyshare/mod.rs
+++ b/node/src/keyshare/mod.rs
@@ -1,168 +1,383 @@
-pub mod gcp;
+pub mod compat;
+mod gcp;
 pub mod local;
+pub mod permanent;
+mod temporary;
+#[cfg(test)]
+pub mod test_utils;
 
-use cait_sith::KeygenOutput;
-use k256::{AffinePoint, Scalar, Secp256k1};
-use mpc_contract::primitives::{
-    domain::DomainId,
-    key_state::{AttemptId, EpochId, KeyEventId},
-};
+use crate::hkdf::affine_point_to_public_key;
+use anyhow::Context;
+use k256::{AffinePoint, Scalar};
+use mpc_contract::primitives::key_state::Keyset;
+use mpc_contract::primitives::key_state::{EpochId, KeyEventId, KeyForDomain};
+use permanent::{PermanentKeyStorage, PermanentKeyStorageBackend, PermanentKeyshareData};
 use serde::{Deserialize, Serialize};
+use temporary::TemporaryKeyStorage;
 
-use crate::indexer::participants::ContractKeyset;
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Secp256k1Data {
     pub private_share: Scalar,
     pub public_key: AffinePoint,
 }
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum KeyShareData {
     Secp256k1(Secp256k1Data),
 }
 
-// The keystore is a mess right now, because changes will depend on PR #278.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyShare {
     pub key_id: KeyEventId,
     pub data: KeyShareData,
 }
+
 impl KeyShare {
-    //pub fn domain_id(&self) -> DomainId {
-    //    self.key_id.domain_id
-    //}
-    pub fn epoch_id(&self) -> EpochId {
-        self.key_id.epoch_id
-    }
-    pub fn attempt_id(&self) -> AttemptId {
-        self.key_id.attempt_id
-    }
-    pub fn keygen_output(&self) -> KeygenOutput<Secp256k1> {
-        KeygenOutput {
-            private_share: self.private_share,
-            public_key: self.public_key,
+    pub fn public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
+        match &self.data {
+            KeyShareData::Secp256k1(secp256k1_data) => {
+                let public_key = affine_point_to_public_key(secp256k1_data.public_key)?;
+                Ok(public_key.to_string().parse()?)
+            }
         }
     }
-    pub fn new(key_id: KeyEventId, keygen_output: KeygenOutput<Secp256k1>) -> Self {
-        Self {
-            key_id,
-            private_share: keygen_output.private_share,
-            public_key: keygen_output.public_key,
+
+    pub fn check_consistency(&self, epoch_id: EpochId, key: &KeyForDomain) -> anyhow::Result<()> {
+        let key_id = KeyEventId::new(epoch_id, key.domain_id, key.attempt);
+        if self.key_id != key_id {
+            anyhow::bail!(
+                "Keyshare has incorrect key ID {:?}, should be {:?}",
+                self.key_id,
+                key_id
+            );
         }
-    }
-}
-pub fn migrate_root_key_share_data(root_keyshare: RootKeyshareData) -> KeyShare {
-    KeyShare {
-        key_id: KeyEventId::new(
-            EpochId::new(root_keyshare.epoch),
-            DomainId::legacy_ecdsa_id(),
-            AttemptId::legacy_attempt_id(),
-        ),
-        private_share: root_keyshare.private_share,
-        public_key: root_keyshare.public_key,
-    }
-}
-/// The root keyshare data along with an epoch. The epoch is incremented
-/// for each key resharing. This is the format stored in the old MPC
-/// implementation, and we're keeping it the same to ease migration.
-/// Deprecated
-#[derive(Clone, Serialize, Deserialize)]
-pub struct RootKeyshareData {
-    pub epoch: u64,
-    pub private_share: Scalar,
-    pub public_key: AffinePoint,
-}
-#[cfg(test)]
-impl RootKeyshareData {
-    //pub fn keygen_output(&self) -> KeygenOutput<Secp256k1> {
-    //    KeygenOutput {
-    //        private_share: self.private_share,
-    //        public_key: self.public_key,
-    //    }
-    //}
-
-    pub fn new(epoch: u64, keygen_output: KeygenOutput<Secp256k1>) -> Self {
-        Self {
-            epoch,
-            private_share: keygen_output.private_share,
-            public_key: keygen_output.public_key,
+        if self.public_key()? != key.key {
+            anyhow::bail!(
+                "Keyshare has incorrect public key {:?}, should be {:?}",
+                self.public_key()?,
+                key.key
+            );
         }
+        Ok(())
     }
 }
 
-/// Abstracts away the storage of the root keyshare data.
-#[async_trait::async_trait]
-pub trait KeyshareStorage: Send {
-    /// Loads the most recent root keyshare data. Returns an error if the data
-    /// cannot be read. Returns Ok(None) if the data does not exist (i.e. we've
-    /// never participated successfully in a key generation).
-    /// todo: add epoch_id as argument?
-    async fn load(&self) -> anyhow::Result<Option<KeyShare>>;
+/// Abstracts away the storage of the keyshares.
+///
+/// The keyshares are stored in "permanent key storage" and "temporary key storage":
+///  - Permanent key storage is a single object that lives either on GCP or locally.
+///  - Temporary key storage is a collection of keyshares that are persisted as individual files.
+///    Each keyshare is identified by (epoch ID, domain ID, attempt ID).
+///
+/// Important: although "temporary key storage" uses the word "temporary", files must still be
+/// strongly persisted and it is not acceptable to delete the local files. The persistence
+/// requirements of the temporary and permanent key storages are the same (i.e. node operators
+/// must not lose them, for doing so is the same as permanently leaving the MPC network).
+///
+/// Keyshares persisted into temporary key storage are not guaranteed to be used; rather, the
+/// voting mechanism (vote_pk and vote_reshared) on the contract ultimately decides which
+/// keyshare to use for each domain (in case multiple attempts were made to generate or reshare
+/// the key).
+///
+/// Whenever the contract transitions into the Running state (which certifies the exact key to
+/// use for each domain), the keyshares are promoted from temporary key storage to permanent key
+/// storage. This is done by calling `load_keyset` when handling the Running state.
+///
+/// A subtle detail is that we may miss the Running state if it quickly transitions into
+/// another state (Initializing or Resharing). For the initializing state we do not actually need
+/// the existing keyshares, but for the resharing state we do. And that's not a problem:
+/// in the resharing state we also need to call `load_keyset`, and that will promote the keys into
+/// permanent storage if needed.
+pub struct KeyshareStorage {
+    temporary: TemporaryKeyStorage,
+    permanent: PermanentKeyStorage,
+}
 
-    /// Stores the most recent root keyshare data. This can only succeed if the
-    /// keyshare didn't exist before or if the new data has a higher epoch.
-    async fn store(&self, key_share: &KeyShare) -> anyhow::Result<()>;
+impl KeyshareStorage {
+    /// Stores a single keyshare into temporary key storage. The keyshare's KeyEventId must be
+    /// unique. This must be called before sending in a vote_pk or vote_reshared.
+    pub async fn store_key(&self, key_share: KeyShare) -> anyhow::Result<()> {
+        self.temporary.store_keyshare(key_share).await
+    }
 
-    async fn load_keyset(&self, keyset: &ContractKeyset) -> anyhow::Result<Vec<KeyShare>>;
+    /// Before generating a key, we must call `ensure_can_generate_key` to check that we are able
+    /// to generate that key and use it afterwards. This requires:
+    ///  - The already generated keys exist either in permanent or temporary storage.
+    ///  - The current permanent key storage is either
+    ///    - In the same epoch as the key generation attempt, and whose keys are a prefix of the
+    ///      already generated keys.
+    ///    - In an older epoch. This can happen if we missed the previous transition from Resharing
+    ///      to Running before it transitions again into Initializing. This is fine.
+    pub async fn ensure_can_generate_key(
+        &self,
+        epoch_id: EpochId,
+        already_generated_keys: &[KeyForDomain],
+    ) -> anyhow::Result<()> {
+        let permanent = self.permanent.load().await?;
+        let num_permanent_keys_same_epoch = if let Some(permanent) = permanent {
+            if permanent.epoch_id == epoch_id {
+                self.verify_existing_keyshares_are_prefix_of_keyset(
+                    &permanent.keyshares,
+                    epoch_id,
+                    already_generated_keys,
+                )
+                .await?;
+                permanent.keyshares.len()
+            } else if permanent.epoch_id.get() > epoch_id.get() {
+                anyhow::bail!(
+                    "Permanent key storage has epoch ID {} which is newer than {}",
+                    permanent.epoch_id.get(),
+                    epoch_id.get()
+                );
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+        for domain in &already_generated_keys[num_permanent_keys_same_epoch..] {
+            self.load_keyshare_from_temporary(epoch_id, domain).await?;
+        }
+        Ok(())
+    }
+
+    /// Before resharing a key, we must call this to ensure that we're able to reshare the key
+    /// and use it afterwards. This requires:
+    ///   - The already reshared keys exist in temporary storage.
+    ///   - The current permanent key storage has an older epoch.
+    pub async fn ensure_can_reshare_key(
+        &self,
+        epoch_id: EpochId,
+        already_reshared_keys: &[KeyForDomain],
+    ) -> anyhow::Result<()> {
+        let permanent = self.permanent.load().await?;
+        if let Some(permanent) = permanent {
+            if permanent.epoch_id.get() >= epoch_id.get() {
+                anyhow::bail!(
+                    "Permanent key storage has epoch ID {} which is not older than {}",
+                    permanent.epoch_id.get(),
+                    epoch_id.get()
+                );
+            }
+        }
+        for domain in already_reshared_keys {
+            self.load_keyshare_from_temporary(epoch_id, domain).await?;
+        }
+        Ok(())
+    }
+
+    /// Ensures that the given keyset is in permanent key storage, and then returns them. The order
+    /// the keys are given and returned are both in increasing order of DomainId.
+    ///
+    /// Since this is only expected to be called when we already know which attempt to use, this
+    /// function also deletes keyshares in temporary storage that are below the keyset's epoch ID.
+    /// (We could also delete attempts in the same epoch ID but this is not necessary from a
+    /// security perspective, since the same epoch ID corresponds to the same set of participants
+    /// and the threshold value.)
+    pub async fn load_keyset(&self, keyset: &Keyset) -> anyhow::Result<Vec<KeyShare>> {
+        let permanent = self.permanent.load().await?;
+        let existing_keyshares = if let Some(permanent) = permanent {
+            if permanent.epoch_id == keyset.epoch_id {
+                permanent.keyshares
+            } else {
+                Vec::new()
+            }
+        } else {
+            Vec::new()
+        };
+        self.verify_existing_keyshares_are_prefix_of_keyset(
+            &existing_keyshares,
+            keyset.epoch_id,
+            &keyset.domains,
+        )
+        .await?;
+
+        if existing_keyshares.len() == keyset.domains.len() {
+            return Ok(existing_keyshares);
+        }
+
+        let mut new_keyshares = existing_keyshares;
+        for domain in keyset.domains.iter().skip(new_keyshares.len()) {
+            let key_id = KeyEventId::new(keyset.epoch_id, domain.domain_id, domain.attempt);
+            let keyshare = self
+                .temporary
+                .load_keyshare(&key_id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Missing temporary keyshare {:?}", key_id))?;
+            new_keyshares.push(keyshare);
+        }
+        let new_permanent_keyshare = PermanentKeyshareData {
+            epoch_id: keyset.epoch_id,
+            keyshares: new_keyshares.clone(),
+        };
+        self.permanent.store(&new_permanent_keyshare).await?;
+        self.temporary
+            .delete_keyshares_prior_to_epoch_id(keyset.epoch_id)
+            .await?;
+        Ok(new_keyshares)
+    }
+
+    async fn verify_existing_keyshares_are_prefix_of_keyset(
+        &self,
+        existing_keyshares: &[KeyShare],
+        epoch_id: EpochId,
+        expected_keys: &[KeyForDomain],
+    ) -> anyhow::Result<()> {
+        if existing_keyshares.len() > expected_keys.len() {
+            anyhow::bail!(
+                "Existing permanent keyshare for epoch {:?} has more domains {} than expected {}",
+                epoch_id,
+                existing_keyshares.len(),
+                expected_keys.len()
+            );
+        }
+        for (i, existing_keyshare) in existing_keyshares.iter().enumerate() {
+            let domain = &expected_keys[i];
+            existing_keyshare
+                .check_consistency(epoch_id, domain)
+                .with_context(|| {
+                    format!(
+                        "Existing permanent keyshare epoch {:?} index {}",
+                        epoch_id, i
+                    )
+                })?;
+        }
+        Ok(())
+    }
+
+    async fn load_keyshare_from_temporary(
+        &self,
+        epoch_id: EpochId,
+        key: &KeyForDomain,
+    ) -> anyhow::Result<KeyShare> {
+        let key_id = KeyEventId::new(epoch_id, key.domain_id, key.attempt);
+        let keyshare = self
+            .temporary
+            .load_keyshare(&key_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Missing temporary keyshare {:?}", key_id))?;
+        keyshare
+            .check_consistency(epoch_id, key)
+            .with_context(|| format!("Keyshare loaded from temporary storage for {:?}", key_id))?;
+        Ok(keyshare)
+    }
+}
+
+pub struct GcpPermanentKeyStorageConfig {
+    pub project_id: String,
+    pub secret_id: String,
 }
 
 /// Factory to construct a KeyshareStorage implementation.
-pub enum KeyshareStorageFactory {
-    Gcp {
-        project_id: String,
-        secret_id: String,
-    },
-    Local {
-        home_dir: std::path::PathBuf,
-        encryption_key: [u8; 16],
-    },
+pub struct KeyStorageConfig {
+    pub home_dir: std::path::PathBuf,
+    pub local_encryption_key: [u8; 16],
+    pub gcp: Option<GcpPermanentKeyStorageConfig>,
 }
 
-impl KeyshareStorageFactory {
-    pub async fn create(&self) -> anyhow::Result<Box<dyn KeyshareStorage>> {
-        match self {
-            Self::Gcp {
-                project_id,
-                secret_id,
-            } => {
-                let storage =
-                    gcp::GcpKeyshareStorage::new(project_id.clone(), secret_id.clone()).await?;
-                Ok(Box::new(storage))
-            }
-            Self::Local {
-                home_dir,
-                encryption_key,
-            } => {
-                let storage = local::LocalKeyshareStorage::new(home_dir.clone(), *encryption_key);
-                Ok(Box::new(storage))
-            }
-        }
+impl KeyStorageConfig {
+    pub async fn create(&self) -> anyhow::Result<KeyshareStorage> {
+        let permanent_backend: Box<dyn PermanentKeyStorageBackend> = if let Some(gcp) = &self.gcp {
+            let backend = gcp::GcpPermanentKeyStorageBackend::new(
+                gcp.project_id.clone(),
+                gcp.secret_id.clone(),
+            )
+            .await?;
+            Box::new(backend)
+        } else {
+            let backend = local::LocalPermanentKeyStorageBackend::new(
+                self.home_dir.clone(),
+                self.local_encryption_key,
+            )
+            .await?;
+            Box::new(backend)
+        };
+        let permanent = PermanentKeyStorage::new(permanent_backend).await?;
+        let temporary = TemporaryKeyStorage::new(self.home_dir.clone(), self.local_encryption_key)?;
+        Ok(KeyshareStorage {
+            temporary,
+            permanent,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use mpc_contract::primitives::key_state::AttemptId;
-    use rand::Rng;
-
-    use crate::{
-        keyshare::{migrate_root_key_share_data, RootKeyshareData},
-        tests::TestGenerators,
+    use super::KeyStorageConfig;
+    use crate::keyshare::test_utils::{
+        generate_dummy_keyshare, keyset_from_permanent_keyshare, permanent_keyshare_from_keyshares,
     };
 
-    #[test]
-    fn test_migration() {
-        let generated_key = TestGenerators::new(2, 2)
-            .make_keygens()
-            .into_iter()
-            .next()
-            .unwrap()
-            .1;
-        let epoch_id = rand::thread_rng().gen();
-        let expected = RootKeyshareData::new(epoch_id, generated_key.clone());
-        let migrated = migrate_root_key_share_data(expected.clone());
-        assert_eq!(migrated.attempt_id(), AttemptId::legacy_attempt_id());
-        assert_eq!(migrated.epoch_id().get(), epoch_id);
-        assert_eq!(migrated.private_share, expected.private_share);
-        assert_eq!(migrated.public_key, expected.public_key);
+    #[tokio::test]
+    async fn test_key_storage() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let home_dir = tempdir.path().to_path_buf();
+        let local_encryption_key = [3; 16];
+        let storage = KeyStorageConfig {
+            home_dir,
+            local_encryption_key,
+            gcp: None,
+        }
+        .create()
+        .await
+        .unwrap();
+
+        // Load an empty keyset; this should succeed.
+        let permanent0 = permanent_keyshare_from_keyshares(0, &[]);
+        let keyset0 = keyset_from_permanent_keyshare(&permanent0);
+        let loaded0 = storage.load_keyset(&keyset0).await.unwrap();
+        assert!(&loaded0.is_empty());
+
+        // Store some keyshares.
+        let key1 = generate_dummy_keyshare(0, 1, 1);
+        let key2 = generate_dummy_keyshare(0, 1, 2);
+        let key3 = generate_dummy_keyshare(0, 2, 1);
+        let key4 = generate_dummy_keyshare(0, 2, 2);
+
+        storage.store_key(key1.clone()).await.unwrap();
+        storage.store_key(key2.clone()).await.unwrap();
+        storage.store_key(key3.clone()).await.unwrap();
+        storage.store_key(key4.clone()).await.unwrap();
+
+        // Finalize two keys from epoch 0.
+        let permanent1 = permanent_keyshare_from_keyshares(0, &[key2.clone(), key3.clone()]);
+        let keyset1 = keyset_from_permanent_keyshare(&permanent1);
+        let loaded1 = storage.load_keyset(&keyset1).await.unwrap();
+        assert_eq!(&loaded1, &permanent1.keyshares);
+
+        // Load a conflicting keyset; this should fail.
+        let permanent2 = permanent_keyshare_from_keyshares(0, &[key1.clone(), key4.clone()]);
+        let keyset2 = keyset_from_permanent_keyshare(&permanent2);
+        assert!(storage.load_keyset(&keyset2).await.is_err());
+
+        // Load the same keyset again; this should succeed.
+        let loaded1 = storage.load_keyset(&keyset1).await.unwrap();
+        assert_eq!(&loaded1, &permanent1.keyshares);
+
+        // Store some more keyshares for epoch 1.
+        let key5 = generate_dummy_keyshare(1, 1, 1);
+        let key6 = generate_dummy_keyshare(1, 1, 2);
+        let key7 = generate_dummy_keyshare(1, 2, 1);
+        let key8 = generate_dummy_keyshare(1, 2, 2);
+        storage.store_key(key5.clone()).await.unwrap();
+        storage.store_key(key6.clone()).await.unwrap();
+        storage.store_key(key7.clone()).await.unwrap();
+        storage.store_key(key8.clone()).await.unwrap();
+
+        // Finalize two keys from epoch 1.
+        let permanent3 = permanent_keyshare_from_keyshares(1, &[key5.clone(), key8.clone()]);
+        let keyset3 = keyset_from_permanent_keyshare(&permanent3);
+        let loaded3 = storage.load_keyset(&keyset3).await.unwrap();
+        assert_eq!(&loaded3, &permanent3.keyshares);
+
+        // Cannot load the old keyset anymore.
+        assert!(storage.load_keyset(&keyset1).await.is_err());
+
+        // Add another key to the same epoch; this is fine.
+        let key9 = generate_dummy_keyshare(1, 3, 1);
+        storage.store_key(key9.clone()).await.unwrap();
+        let permanent4 = permanent_keyshare_from_keyshares(1, &[key5.clone(), key8.clone(), key9]);
+        let keyset4 = keyset_from_permanent_keyshare(&permanent4);
+        let loaded4 = storage.load_keyset(&keyset4).await.unwrap();
+        assert_eq!(&loaded4, &permanent4.keyshares);
     }
 }

--- a/node/src/keyshare/permanent.rs
+++ b/node/src/keyshare/permanent.rs
@@ -1,0 +1,205 @@
+use super::KeyShare;
+use anyhow::Context;
+use k256::{AffinePoint, Scalar};
+use mpc_contract::primitives::key_state::EpochId;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PermanentKeyshareData {
+    pub epoch_id: EpochId,
+    pub keyshares: Vec<KeyShare>,
+}
+
+impl PermanentKeyshareData {
+    pub fn from_legacy(legacy: &LegacyRootKeyshareData) -> Self {
+        Self {
+            epoch_id: EpochId::new(legacy.epoch),
+            keyshares: vec![KeyShare::from_legacy(legacy)],
+        }
+    }
+}
+
+#[async_trait::async_trait]
+pub trait PermanentKeyStorageBackend: Send + Sync {
+    async fn load(&self) -> anyhow::Result<Option<Vec<u8>>>;
+    async fn store(&self, data: &[u8], identifier: &str) -> anyhow::Result<()>;
+}
+
+pub struct PermanentKeyStorage {
+    backend: Box<dyn PermanentKeyStorageBackend>,
+}
+
+impl PermanentKeyStorage {
+    pub async fn new(backend: Box<dyn PermanentKeyStorageBackend>) -> anyhow::Result<Self> {
+        let ret = Self { backend };
+        let existing_data = ret.backend.load().await?;
+        if let Some(data) = existing_data {
+            if serde_json::from_slice::<PermanentKeyshareData>(&data).is_err() {
+                tracing::info!("Existing permanent keyshare data is not in the expected format, attempting to migrate...");
+                let legacy_data = serde_json::from_slice::<LegacyRootKeyshareData>(&data)?;
+                let new_data = PermanentKeyshareData::from_legacy(&legacy_data);
+                ret.store(&new_data).await?;
+            }
+        }
+        Ok(ret)
+    }
+
+    pub async fn load(&self) -> anyhow::Result<Option<PermanentKeyshareData>> {
+        let data = self.backend.load().await?;
+        Ok(data.map(|data| serde_json::from_slice(&data)).transpose()?)
+    }
+
+    pub async fn store(&self, keyshare_data: &PermanentKeyshareData) -> anyhow::Result<()> {
+        let existing = self.load().await.context("Checking existing keyshare")?;
+        if let Some(existing) = existing {
+            if existing.epoch_id.get() > keyshare_data.epoch_id.get() {
+                return Err(anyhow::anyhow!(
+                    "Refusing to overwrite existing permanent keyshare of epoch {} with new permanent keyshare of older epoch {}",
+                    existing.epoch_id.get(),
+                    keyshare_data.epoch_id.get(),
+                ));
+            } else if existing.epoch_id.get() == keyshare_data.epoch_id.get()
+                && existing.keyshares.len() >= keyshare_data.keyshares.len()
+            {
+                return Err(anyhow::anyhow!(
+                    "Refusing to overwrite existing permanent keyshare of epoch {} with new permanent keyshare of same epoch but equal or fewer domains",
+                    existing.epoch_id.get(),
+                ));
+            }
+        }
+
+        let data_json = serde_json::to_vec(keyshare_data)?;
+        let identifier = format!(
+            "epoch_{}_with_{}_domains",
+            keyshare_data.epoch_id.get(),
+            keyshare_data.keyshares.len()
+        );
+        self.backend.store(&data_json, &identifier).await
+    }
+}
+
+/// Old version of the permanent keyshare data, for migration only.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct LegacyRootKeyshareData {
+    pub epoch: u64,
+    pub private_share: Scalar,
+    pub public_key: AffinePoint,
+}
+
+impl LegacyRootKeyshareData {
+    pub fn keygen_output(&self) -> cait_sith::KeygenOutput<k256::Secp256k1> {
+        cait_sith::KeygenOutput {
+            private_share: self.private_share,
+            public_key: self.public_key,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PermanentKeyshareData;
+    use crate::keyshare::local::LocalPermanentKeyStorageBackend;
+    use crate::keyshare::permanent::{
+        LegacyRootKeyshareData, PermanentKeyStorage, PermanentKeyStorageBackend,
+    };
+    use crate::keyshare::test_utils::{generate_dummy_keyshare, permanent_keyshare_from_keyshares};
+    use crate::keyshare::{KeyShareData, Secp256k1Data};
+    use k256::elliptic_curve::Field;
+    use k256::{AffinePoint, Scalar};
+    use mpc_contract::primitives::key_state::EpochId;
+
+    #[tokio::test]
+    async fn test_load_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let encryption_key = [2; 16];
+        let backend =
+            LocalPermanentKeyStorageBackend::new(temp.path().to_path_buf(), encryption_key)
+                .await
+                .unwrap();
+        let storage = PermanentKeyStorage::new(Box::new(backend)).await.unwrap();
+        assert!(storage.load().await.unwrap().is_none());
+
+        let keys = vec![
+            generate_dummy_keyshare(1, 0, 1),
+            generate_dummy_keyshare(1, 2, 4),
+        ];
+        let permanent_keyshare = PermanentKeyshareData {
+            epoch_id: EpochId::new(1),
+            keyshares: keys.clone(),
+        };
+
+        storage.store(&permanent_keyshare).await.unwrap();
+        let loaded = storage.load().await.unwrap().unwrap();
+        assert_eq!(loaded, permanent_keyshare);
+
+        // Cannot store the same permanent keyshare twice.
+        assert!(storage.store(&permanent_keyshare).await.is_err());
+        // Cannot store current epoch with fewer domains.
+        let keys = vec![generate_dummy_keyshare(1, 0, 1)];
+        let permanent_keyshare = permanent_keyshare_from_keyshares(1, &keys);
+        assert!(storage.store(&permanent_keyshare).await.is_err());
+        // Cannot store older epoch than current.
+        let keys = vec![
+            generate_dummy_keyshare(0, 0, 1),
+            generate_dummy_keyshare(0, 2, 2),
+        ];
+        let permanent_keyshare = permanent_keyshare_from_keyshares(0, &keys);
+        assert!(storage.store(&permanent_keyshare).await.is_err());
+
+        // Can store newer epoch than current.
+        let keys = vec![
+            generate_dummy_keyshare(2, 0, 1),
+            generate_dummy_keyshare(2, 2, 2),
+        ];
+        let permanent_keyshare = permanent_keyshare_from_keyshares(2, &keys);
+        storage.store(&permanent_keyshare).await.unwrap();
+        let loaded = storage.load().await.unwrap().unwrap();
+        assert_eq!(loaded, permanent_keyshare);
+
+        // Can store current epoch with more domains.
+        let keys = vec![
+            generate_dummy_keyshare(2, 0, 1),
+            generate_dummy_keyshare(2, 2, 2),
+            generate_dummy_keyshare(2, 3, 5),
+        ];
+        let permanent_keyshare = permanent_keyshare_from_keyshares(2, &keys);
+        storage.store(&permanent_keyshare).await.unwrap();
+        let loaded = storage.load().await.unwrap().unwrap();
+        assert_eq!(loaded, permanent_keyshare);
+    }
+
+    #[tokio::test]
+    async fn test_legacy_migration() {
+        let temp = tempfile::tempdir().unwrap();
+        let encryption_key = [2; 16];
+        let backend =
+            LocalPermanentKeyStorageBackend::new(temp.path().to_path_buf(), encryption_key)
+                .await
+                .unwrap();
+        // Write a legacy keyshare.
+        let legacy_data = LegacyRootKeyshareData {
+            epoch: 1,
+            private_share: Scalar::random(&mut rand::thread_rng()),
+            public_key: AffinePoint::IDENTITY,
+        };
+        let legacy_data_json = serde_json::to_vec(&legacy_data).unwrap();
+        let identifier = "whatever";
+        backend.store(&legacy_data_json, identifier).await.unwrap();
+
+        // Make the storage. The storage should upgrade the legacy keyshare to the new format.
+        let storage = PermanentKeyStorage::new(Box::new(backend)).await.unwrap();
+        let loaded = storage.load().await.unwrap().unwrap();
+        assert_eq!(loaded.epoch_id.get(), 1);
+        assert_eq!(loaded.keyshares.len(), 1);
+        assert_eq!(loaded.keyshares[0].key_id.epoch_id.get(), 1);
+        assert_eq!(loaded.keyshares[0].key_id.domain_id.0, 0);
+        assert_eq!(loaded.keyshares[0].key_id.attempt_id.get(), 0);
+        assert_eq!(
+            loaded.keyshares[0].data,
+            KeyShareData::Secp256k1(Secp256k1Data {
+                private_share: legacy_data.private_share,
+                public_key: legacy_data.public_key,
+            })
+        );
+    }
+}

--- a/node/src/keyshare/permanent.rs
+++ b/node/src/keyshare/permanent.rs
@@ -120,7 +120,7 @@ mod tests {
         LegacyRootKeyshareData, PermanentKeyStorage, PermanentKeyStorageBackend,
     };
     use crate::keyshare::test_utils::{generate_dummy_keyshare, permanent_keyshare_from_keyshares};
-    use crate::keyshare::{KeyshareData, Secp256k1KeyshareData};
+    use crate::keyshare::KeyshareData;
     use k256::elliptic_curve::Field;
     use k256::{AffinePoint, Scalar};
     use mpc_contract::primitives::key_state::EpochId;
@@ -213,7 +213,7 @@ mod tests {
         assert_eq!(loaded.keyshares[0].key_id.attempt_id.get(), 0);
         assert_eq!(
             loaded.keyshares[0].data,
-            KeyshareData::Secp256k1(Secp256k1KeyshareData {
+            KeyshareData::Secp256k1(cait_sith::KeygenOutput {
                 private_share: legacy_data.private_share,
                 public_key: legacy_data.public_key,
             })

--- a/node/src/keyshare/permanent.rs
+++ b/node/src/keyshare/permanent.rs
@@ -1,30 +1,41 @@
-use super::KeyShare;
+use super::Keyshare;
 use anyhow::Context;
 use k256::{AffinePoint, Scalar};
 use mpc_contract::primitives::key_state::EpochId;
 use serde::{Deserialize, Serialize};
 
+/// The single object we persist to permanent key storage.
+/// Corresponds to a Keyset in the contract side (i.e. one keyshare per domain).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PermanentKeyshareData {
     pub epoch_id: EpochId,
-    pub keyshares: Vec<KeyShare>,
+    /// These keyshares are in the exact same order as the domains in the Keyset.
+    pub keyshares: Vec<Keyshare>,
 }
 
 impl PermanentKeyshareData {
     pub fn from_legacy(legacy: &LegacyRootKeyshareData) -> Self {
         Self {
             epoch_id: EpochId::new(legacy.epoch),
-            keyshares: vec![KeyShare::from_legacy(legacy)],
+            keyshares: vec![Keyshare::from_legacy(legacy)],
         }
     }
 }
 
+/// Backend for storing the permanent keyshare data.
 #[async_trait::async_trait]
 pub trait PermanentKeyStorageBackend: Send + Sync {
+    /// Loads the latest stored data; or None if no data was ever stored.
     async fn load(&self) -> anyhow::Result<Option<Vec<u8>>>;
+    /// Stores the data, making it the latest. The identifier is used for the local backend to write
+    /// the data to a separate file and then linking it to the main file (acting as a backup
+    /// mechanism).
     async fn store(&self, data: &[u8], identifier: &str) -> anyhow::Result<()>;
 }
 
+/// Manages permanent keyshares. These are the keyshares we see from the Running state.
+/// When we generate or reshare a key, that key goes into temporary key storage first,
+/// and only when we transition to Running do we move it to permanent key storage.
 pub struct PermanentKeyStorage {
     backend: Box<dyn PermanentKeyStorageBackend>,
 }
@@ -32,13 +43,15 @@ pub struct PermanentKeyStorage {
 impl PermanentKeyStorage {
     pub async fn new(backend: Box<dyn PermanentKeyStorageBackend>) -> anyhow::Result<Self> {
         let ret = Self { backend };
+
+        // Migrate legacy data if necessary.
         let existing_data = ret.backend.load().await?;
         if let Some(data) = existing_data {
             if serde_json::from_slice::<PermanentKeyshareData>(&data).is_err() {
                 tracing::info!("Existing permanent keyshare data is not in the expected format, attempting to migrate...");
                 let legacy_data = serde_json::from_slice::<LegacyRootKeyshareData>(&data)?;
                 let new_data = PermanentKeyshareData::from_legacy(&legacy_data);
-                ret.store(&new_data).await?;
+                ret.store_unchecked(&new_data).await?;
             }
         }
         Ok(ret)
@@ -68,6 +81,10 @@ impl PermanentKeyStorage {
             }
         }
 
+        self.store_unchecked(keyshare_data).await
+    }
+
+    async fn store_unchecked(&self, keyshare_data: &PermanentKeyshareData) -> anyhow::Result<()> {
         let data_json = serde_json::to_vec(keyshare_data)?;
         let identifier = format!(
             "epoch_{}_with_{}_domains",
@@ -103,7 +120,7 @@ mod tests {
         LegacyRootKeyshareData, PermanentKeyStorage, PermanentKeyStorageBackend,
     };
     use crate::keyshare::test_utils::{generate_dummy_keyshare, permanent_keyshare_from_keyshares};
-    use crate::keyshare::{KeyShareData, Secp256k1Data};
+    use crate::keyshare::{KeyshareData, Secp256k1KeyshareData};
     use k256::elliptic_curve::Field;
     use k256::{AffinePoint, Scalar};
     use mpc_contract::primitives::key_state::EpochId;
@@ -196,7 +213,7 @@ mod tests {
         assert_eq!(loaded.keyshares[0].key_id.attempt_id.get(), 0);
         assert_eq!(
             loaded.keyshares[0].data,
-            KeyShareData::Secp256k1(Secp256k1Data {
+            KeyshareData::Secp256k1(Secp256k1KeyshareData {
                 private_share: legacy_data.private_share,
                 public_key: legacy_data.public_key,
             })

--- a/node/src/keyshare/temporary.rs
+++ b/node/src/keyshare/temporary.rs
@@ -1,0 +1,156 @@
+use super::KeyShare;
+use crate::db::{decrypt, encrypt};
+use aes_gcm::{Aes128Gcm, KeyInit};
+use mpc_contract::primitives::key_state::{EpochId, KeyEventId};
+use sha3::digest::generic_array::GenericArray;
+use std::path::PathBuf;
+use tokio::io::AsyncWriteExt;
+
+pub struct TemporaryKeyStorage {
+    storage_dir: PathBuf,
+    cipher: Aes128Gcm,
+}
+
+impl TemporaryKeyStorage {
+    pub fn new(home_dir: PathBuf, local_encryption_key: [u8; 16]) -> anyhow::Result<Self> {
+        let storage_dir = home_dir.join("temporary_keys");
+        std::fs::create_dir_all(&storage_dir)?;
+        Ok(Self {
+            storage_dir,
+            cipher: Aes128Gcm::new(GenericArray::from_slice(&local_encryption_key)),
+        })
+    }
+
+    fn keyshare_path(&self, key_id: &KeyEventId) -> PathBuf {
+        let filename = format!(
+            "keyshare_{}_{}_{}",
+            key_id.epoch_id.get(),
+            key_id.domain_id.0,
+            key_id.attempt_id.get()
+        );
+        self.storage_dir.join(filename)
+    }
+
+    pub async fn store_keyshare(&self, keyshare: KeyShare) -> anyhow::Result<()> {
+        let path = self.keyshare_path(&keyshare.key_id);
+        let data = serde_json::to_vec(&keyshare)?;
+        let encrypted = encrypt(&self.cipher, &data);
+
+        let mut file = tokio::fs::File::create_new(&path).await?;
+        file.write_all(&encrypted).await?;
+        file.sync_all().await?;
+        Ok(())
+    }
+
+    pub async fn load_keyshare(&self, key_id: &KeyEventId) -> anyhow::Result<Option<KeyShare>> {
+        let path = self.keyshare_path(key_id);
+        if tokio::fs::try_exists(&path).await? {
+            return Ok(None);
+        }
+
+        let data = tokio::fs::read(&path).await?;
+        let decrypted = decrypt(&self.cipher, &data)?;
+        let keyshare: KeyShare = serde_json::from_slice(&decrypted)?;
+        if keyshare.key_id != *key_id {
+            anyhow::bail!(
+                "Keyshare loaded from {:?} has unexpected key ID {:?}",
+                path,
+                keyshare.key_id
+            );
+        }
+        Ok(Some(keyshare))
+    }
+
+    fn get_epoch_id_from_filename(filename: &str) -> anyhow::Result<EpochId> {
+        let parts: Vec<&str> = filename.split('_').collect();
+        if parts.len() != 4 {
+            anyhow::bail!("Invalid keyshare filename: {:?}", filename);
+        }
+        let epoch_id: u64 = parts[1].parse()?;
+        Ok(EpochId::new(epoch_id))
+    }
+
+    pub async fn delete_keyshares_prior_to_epoch_id(
+        &self,
+        epoch_id: EpochId,
+    ) -> anyhow::Result<()> {
+        let mut readdir = tokio::fs::read_dir(&self.storage_dir).await?;
+        while let Some(entry) = readdir.next_entry().await? {
+            let filename = entry.file_name().to_string_lossy().to_string();
+            let existing_epoch_id = Self::get_epoch_id_from_filename(&filename)?;
+            if existing_epoch_id.get() < epoch_id.get() {
+                tokio::fs::remove_file(entry.path()).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::keyshare::temporary::TemporaryKeyStorage;
+    use crate::keyshare::test_utils::generate_dummy_keyshare;
+    use mpc_contract::primitives::key_state::EpochId;
+
+    #[tokio::test]
+    async fn test_temporary_key_storage() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let local_encryption_key = [3; 16];
+        let storage =
+            TemporaryKeyStorage::new(home_dir.path().to_path_buf(), local_encryption_key).unwrap();
+
+        let key1 = generate_dummy_keyshare(1, 2, 1);
+        let key2 = generate_dummy_keyshare(1, 2, 2);
+        let key3 = generate_dummy_keyshare(1, 2, 3);
+        let key4 = generate_dummy_keyshare(1, 3, 2);
+        let key5 = generate_dummy_keyshare(2, 1, 1);
+        let key6 = generate_dummy_keyshare(2, 2, 1);
+        let key7 = generate_dummy_keyshare(3, 1, 7);
+
+        assert!(storage.load_keyshare(&key1.key_id).await.unwrap().is_none());
+
+        storage.store_keyshare(key1.clone()).await.unwrap();
+        storage.store_keyshare(key2.clone()).await.unwrap();
+        storage.store_keyshare(key3.clone()).await.unwrap();
+        storage.store_keyshare(key4.clone()).await.unwrap();
+        storage.store_keyshare(key5.clone()).await.unwrap();
+        storage.store_keyshare(key6.clone()).await.unwrap();
+        storage.store_keyshare(key7.clone()).await.unwrap();
+
+        let loaded1 = storage.load_keyshare(&key1.key_id).await.unwrap().unwrap();
+        assert_eq!(loaded1, key1);
+        let loaded2 = storage.load_keyshare(&key2.key_id).await.unwrap().unwrap();
+        assert_eq!(loaded2, key2);
+        let loaded3 = storage.load_keyshare(&key3.key_id).await.unwrap().unwrap();
+        assert_eq!(loaded3, key3);
+        let loaded4 = storage.load_keyshare(&key4.key_id).await.unwrap().unwrap();
+        assert_eq!(loaded4, key4);
+        let loaded5 = storage.load_keyshare(&key5.key_id).await.unwrap().unwrap();
+        assert_eq!(loaded5, key5);
+        let loaded6 = storage.load_keyshare(&key6.key_id).await.unwrap().unwrap();
+        assert_eq!(loaded6, key6);
+        let loaded7 = storage.load_keyshare(&key7.key_id).await.unwrap().unwrap();
+        assert_eq!(loaded7, key7);
+
+        storage
+            .delete_keyshares_prior_to_epoch_id(EpochId::new(2))
+            .await
+            .unwrap();
+        assert!(storage.load_keyshare(&key1.key_id).await.unwrap().is_none());
+        assert!(storage.load_keyshare(&key2.key_id).await.unwrap().is_none());
+        assert!(storage.load_keyshare(&key3.key_id).await.unwrap().is_none());
+        assert!(storage.load_keyshare(&key4.key_id).await.unwrap().is_none());
+        assert!(storage.load_keyshare(&key5.key_id).await.unwrap().is_some());
+        assert!(storage.load_keyshare(&key6.key_id).await.unwrap().is_some());
+        assert!(storage.load_keyshare(&key7.key_id).await.unwrap().is_some());
+
+        storage
+            .delete_keyshares_prior_to_epoch_id(EpochId::new(3))
+            .await
+            .unwrap();
+
+        assert!(storage.load_keyshare(&key5.key_id).await.unwrap().is_none());
+        assert!(storage.load_keyshare(&key6.key_id).await.unwrap().is_none());
+        assert!(storage.load_keyshare(&key7.key_id).await.unwrap().is_some());
+    }
+}

--- a/node/src/keyshare/test_utils.rs
+++ b/node/src/keyshare/test_utils.rs
@@ -1,28 +1,33 @@
 use super::permanent::PermanentKeyshareData;
-use super::{KeyShare, KeyShareData, Secp256k1Data};
+use super::{Keyshare, KeyshareData, Secp256k1KeyshareData};
 use crate::hkdf::affine_point_to_public_key;
-use k256::elliptic_curve::Field;
-use k256::{AffinePoint, Scalar};
+use crate::tests::TestGenerators;
 use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::key_state::{EpochId, KeyEventId, KeyForDomain, Keyset};
 
-pub fn generate_dummy_keyshare(epoch_id: u64, domain_id: u64, attempt_id: u64) -> KeyShare {
-    KeyShare {
+pub fn generate_dummy_keyshare(epoch_id: u64, domain_id: u64, attempt_id: u64) -> Keyshare {
+    let key = TestGenerators::new(2, 2)
+        .make_keygens()
+        .into_iter()
+        .next()
+        .unwrap()
+        .1;
+    Keyshare {
         key_id: KeyEventId::new(
             EpochId::new(epoch_id),
             DomainId(domain_id),
             serde_json::from_str(&format!("{}", attempt_id)).unwrap(),
         ),
-        data: KeyShareData::Secp256k1(Secp256k1Data {
-            private_share: Scalar::random(&mut rand::thread_rng()),
-            public_key: AffinePoint::IDENTITY,
+        data: KeyshareData::Secp256k1(Secp256k1KeyshareData {
+            private_share: key.private_share,
+            public_key: key.public_key,
         }),
     }
 }
 
 pub fn permanent_keyshare_from_keyshares(
     epoch_id: u64,
-    keyshares: &[KeyShare],
+    keyshares: &[Keyshare],
 ) -> PermanentKeyshareData {
     PermanentKeyshareData {
         epoch_id: EpochId::new(epoch_id),
@@ -36,7 +41,7 @@ pub fn keyset_from_permanent_keyshare(permanent: &PermanentKeyshareData) -> Keys
         .iter()
         .map(|keyshare| {
             let key = match &keyshare.data {
-                KeyShareData::Secp256k1(secp256k1_data) => {
+                KeyshareData::Secp256k1(secp256k1_data) => {
                     affine_point_to_public_key(secp256k1_data.public_key).unwrap()
                 }
             };

--- a/node/src/keyshare/test_utils.rs
+++ b/node/src/keyshare/test_utils.rs
@@ -1,0 +1,51 @@
+use super::permanent::PermanentKeyshareData;
+use super::{KeyShare, KeyShareData, Secp256k1Data};
+use crate::hkdf::affine_point_to_public_key;
+use k256::elliptic_curve::Field;
+use k256::{AffinePoint, Scalar};
+use mpc_contract::primitives::domain::DomainId;
+use mpc_contract::primitives::key_state::{EpochId, KeyEventId, KeyForDomain, Keyset};
+
+pub fn generate_dummy_keyshare(epoch_id: u64, domain_id: u64, attempt_id: u64) -> KeyShare {
+    KeyShare {
+        key_id: KeyEventId::new(
+            EpochId::new(epoch_id),
+            DomainId(domain_id),
+            serde_json::from_str(&format!("{}", attempt_id)).unwrap(),
+        ),
+        data: KeyShareData::Secp256k1(Secp256k1Data {
+            private_share: Scalar::random(&mut rand::thread_rng()),
+            public_key: AffinePoint::IDENTITY,
+        }),
+    }
+}
+
+pub fn permanent_keyshare_from_keyshares(
+    epoch_id: u64,
+    keyshares: &[KeyShare],
+) -> PermanentKeyshareData {
+    PermanentKeyshareData {
+        epoch_id: EpochId::new(epoch_id),
+        keyshares: keyshares.to_vec(),
+    }
+}
+
+pub fn keyset_from_permanent_keyshare(permanent: &PermanentKeyshareData) -> Keyset {
+    let keys = permanent
+        .keyshares
+        .iter()
+        .map(|keyshare| {
+            let key = match &keyshare.data {
+                KeyShareData::Secp256k1(secp256k1_data) => {
+                    affine_point_to_public_key(secp256k1_data.public_key).unwrap()
+                }
+            };
+            KeyForDomain {
+                domain_id: keyshare.key_id.domain_id,
+                key: key.to_string().parse().unwrap(),
+                attempt: keyshare.key_id.attempt_id,
+            }
+        })
+        .collect();
+    Keyset::new(permanent.epoch_id, keys)
+}

--- a/node/src/keyshare/test_utils.rs
+++ b/node/src/keyshare/test_utils.rs
@@ -1,7 +1,8 @@
 use super::permanent::PermanentKeyshareData;
-use super::{Keyshare, KeyshareData, Secp256k1KeyshareData};
+use super::{Keyshare, KeyshareData};
 use crate::hkdf::affine_point_to_public_key;
 use crate::tests::TestGenerators;
+use cait_sith::KeygenOutput;
 use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::key_state::{EpochId, KeyEventId, KeyForDomain, Keyset};
 
@@ -18,7 +19,7 @@ pub fn generate_dummy_keyshare(epoch_id: u64, domain_id: u64, attempt_id: u64) -
             DomainId(domain_id),
             serde_json::from_str(&format!("{}", attempt_id)).unwrap(),
         ),
-        data: KeyshareData::Secp256k1(Secp256k1KeyshareData {
+        data: KeyshareData::Secp256k1(KeygenOutput {
             private_share: key.private_share,
             public_key: key.public_key,
         }),

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -13,7 +13,7 @@ use crate::db::SecretDB;
 use crate::indexer::fake::FakeIndexerManager;
 use crate::indexer::handler::{SignArgs, SignatureRequestFromChain};
 use crate::indexer::IndexerAPI;
-use crate::keyshare::KeyshareStorageFactory;
+use crate::keyshare::KeyStorageConfig;
 use crate::p2p::testing::{generate_test_p2p_configs, PortSeed};
 use crate::primitives::ParticipantId;
 use crate::tracking::{self, start_root_task, AutoAbortTask};
@@ -200,9 +200,10 @@ impl OneNodeTestConfig {
 
                 let secret_db = SecretDB::new(&home_dir, secrets.local_storage_aes_key)?;
 
-                let keyshare_storage_factory = KeyshareStorageFactory::Local {
+                let key_storage_config = KeyStorageConfig {
                     home_dir: home_dir.clone(),
-                    encryption_key: secrets.local_storage_aes_key,
+                    local_encryption_key: secrets.local_storage_aes_key,
+                    gcp: None,
                 };
 
                 let coordinator = Coordinator {
@@ -210,7 +211,7 @@ impl OneNodeTestConfig {
                     config_file: config,
                     secrets,
                     secret_db,
-                    keyshare_storage_factory,
+                    key_storage_config,
                     indexer,
                     currently_running_job_name,
                     signature_debug_request_sender,


### PR DESCRIPTION
This largely adheres to the specification for key storage in this design: https://docs.google.com/document/d/17y1lyyYwB5_iq8abv7A10XqAFjYtz8Ak83Wb3eH8j70/edit?tab=t.0

The strategy I've used here is to actually keep the implementation compatible with the rest of the code, so we can individually merge this PR while keeping the tests passing. However, **this is NOT a good version to actually release to anyone**, **NOR is it a proof or even a suggestion that we can implement this in a backwards-compatible way**, because:
* This will migrate the key storage format, so if anyone runs it in production, it will permanently alter their key storage. We might end up changing things before V2 is actually released, so this would not be good.
* For key import, the imported key *should* still be compatible with old node, but... I would not recommend the risk, so @andrei-near I would recommend that we use a binary older than this PR to import keys.
* Key generation and resharing implementation is no longer resistant to failure. So we should not run these in production either. The reason they are no longer resistant to failure is because keeping that the case with the new key storage would be cumbersome, and we're replacing that code in a matter of days so it isn't worth the trouble.

The addition to the specification is to perform stringent sanity checks before doing keygen and resharing. That's to ensure that when the contract transitions to the Running state, the local node will be able to follow suit. It's not necessary as long as nobody messes with the local storage, but if someone deletes some files in local storage then this would be able to catch issues early.