### PR TITLE
Delete the cipher_pk field in contract V2.

### DIFF
--- a/libs/chain-signatures/contract/src/primitives/participants.rs
+++ b/libs/chain-signatures/contract/src/primitives/participants.rs
@@ -13,8 +13,6 @@ pub mod hpke {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct ParticipantInfo {
     pub url: String,
-    /// The public key used for encrypting messages.
-    pub cipher_pk: hpke::PublicKey,
     /// The public key used for verifying messages.
     pub sign_pk: PublicKey,
 }
@@ -24,7 +22,6 @@ impl From<&legacy_contract_state::ParticipantInfo> for ParticipantInfo {
     fn from(info: &legacy_contract_state::ParticipantInfo) -> ParticipantInfo {
         ParticipantInfo {
             url: info.url.clone(),
-            cipher_pk: info.cipher_pk,
             sign_pk: info.sign_pk.clone(),
         }
     }
@@ -267,7 +264,6 @@ pub mod tests {
             assert!(migrated_participants.is_participant(account_id));
             let mp_info = migrated_participants.info(account_id).unwrap();
             assert_eq!(mp_info.url, info.url);
-            assert_eq!(mp_info.cipher_pk, info.cipher_pk);
             assert_eq!(mp_info.sign_pk, info.sign_pk);
             assert_eq!(
                 *account_id,
@@ -305,7 +301,6 @@ pub mod tests {
             let legacy_participant = legacy_participant.unwrap();
             assert_eq!(legacy_participant.account_id, *account_id);
             assert_eq!(legacy_participant.url, info.url);
-            assert_eq!(legacy_participant.cipher_pk, info.cipher_pk);
             assert_eq!(legacy_participant.sign_pk, info.sign_pk);
             let legacy_idx = *legacy_participants
                 .account_to_participant_id

--- a/libs/chain-signatures/contract/src/primitives/test_utils.rs
+++ b/libs/chain-signatures/contract/src/primitives/test_utils.rs
@@ -43,7 +43,6 @@ pub fn gen_participant(i: usize) -> (AccountId, ParticipantInfo) {
         gen_account_id(),
         ParticipantInfo {
             url: format!("near{}", i),
-            cipher_pk: [0u8; 32],
             sign_pk: gen_pk(),
         },
     )

--- a/libs/chain-signatures/contract/tests/common.rs
+++ b/libs/chain-signatures/contract/tests/common.rs
@@ -49,7 +49,6 @@ pub fn candidates(names: Option<Vec<AccountId>>) -> Participants {
             account_id.clone(),
             ParticipantInfo {
                 url: "127.0.0.1".into(),
-                cipher_pk: [0; 32],
                 sign_pk: near_sdk::PublicKey::from_str(
                     "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
                 )

--- a/libs/chain-signatures/contract/tests/vote.rs
+++ b/libs/chain-signatures/contract/tests/vote.rs
@@ -146,7 +146,6 @@ async fn test_resharing() -> anyhow::Result<()> {
             alice.id().clone(),
             ParticipantInfo {
                 url: "127.0.0.1".to_string(),
-                cipher_pk: [1u8; 32],
                 sign_pk: PublicKey::from_str(
                     "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
                 )?,
@@ -232,7 +231,6 @@ async fn test_repropose_resharing() -> anyhow::Result<()> {
             alice.id().clone(),
             ParticipantInfo {
                 url: "127.0.0.1".to_string(),
-                cipher_pk: [1u8; 32],
                 sign_pk: PublicKey::from_str(
                     "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
                 )


### PR DESCRIPTION
We don't need it at all anymore and we no longer need to be backwards compatible with V1 so just delete it.