### PR TITLE
eddsa integration 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/kuksag/cait-sith?rev=e89e3d96900c52f4e1097d4031dd8ee3b1eb60df#e89e3d96900c52f4e1097d4031dd8ee3b1eb60df"
+source = "git+https://github.com/Near-One/cait-sith?rev=377b1d7c25a8fd1f111d7cced2ccf8efc4b54639#377b1d7c25a8fd1f111d7cced2ccf8efc4b54639"
 dependencies = [
  "auto_ops",
  "ck-meow",

--- a/libs/chain-signatures/contract/src/crypto_shared/types.rs
+++ b/libs/chain-signatures/contract/src/crypto_shared/types.rs
@@ -217,7 +217,7 @@ pub mod edd25519_types {
     #[derive(
         BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone, PartialEq, Eq,
     )]
-    pub struct SignatureResponse(#[serde_as(as = "[_; 64]")] [u8; 64]);
+    pub struct SignatureResponse(#[serde_as(as = "[_; 64]")] pub [u8; 64]);
 
     impl SignatureResponse {
         pub fn as_bytes(&self) -> &[u8; 64] {

--- a/libs/chain-signatures/contract/src/state/key_event.rs
+++ b/libs/chain-signatures/contract/src/state/key_event.rs
@@ -81,6 +81,10 @@ impl KeyEvent {
         self.epoch_id
     }
 
+    pub fn domain(&self) -> DomainConfig {
+        self.domain.clone()
+    }
+
     pub fn proposed_parameters(&self) -> &ThresholdParameters {
         &self.parameters
     }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.92"
 async-trait = "0.1.83"
 axum = "0.7.9"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/kuksag/cait-sith", rev = "e89e3d96900c52f4e1097d4031dd8ee3b1eb60df" }
+cait-sith = { git = "https://github.com/Near-One/cait-sith", rev = "377b1d7c25a8fd1f111d7cced2ccf8efc4b54639" }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"

--- a/node/src/indexer/participants.rs
+++ b/node/src/indexer/participants.rs
@@ -2,6 +2,7 @@ use crate::config::{ParticipantInfo, ParticipantsConfig};
 use crate::indexer::lib::{get_mpc_contract_state, wait_for_contract_code, wait_for_full_sync};
 use crate::primitives::ParticipantId;
 use anyhow::Context;
+use mpc_contract::primitives::domain::DomainConfig;
 use mpc_contract::primitives::key_state::{KeyEventId, KeyForDomain, Keyset};
 use mpc_contract::primitives::thresholds::ThresholdParameters;
 use mpc_contract::state::key_event::KeyEvent;
@@ -14,6 +15,7 @@ use url::Url;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContractKeyEventInstance {
     pub id: KeyEventId,
+    pub domain: DomainConfig,
     pub started: bool,
     pub completed: BTreeSet<ParticipantId>,
     pub completed_domains: Vec<KeyForDomain>,
@@ -32,6 +34,7 @@ pub fn convert_key_event_to_instance(
                     domain_id: key_event.domain_id(),
                     attempt_id: current_instance.attempt_id(),
                 },
+                domain: key_event.domain(),
                 started: true,
                 completed: current_instance
                     .completed()
@@ -47,6 +50,7 @@ pub fn convert_key_event_to_instance(
                 domain_id: key_event.domain_id(),
                 attempt_id: key_event.next_attempt_id(),
             },
+            domain: key_event.domain(),
             started: false,
             completed: BTreeSet::new(),
             completed_domains,

--- a/node/src/keyshare/compat.rs
+++ b/node/src/keyshare/compat.rs
@@ -19,7 +19,12 @@ pub fn legacy_ecdsa_key_from_keyshares(
             keyshare.key_id.domain_id
         );
     }
-    let KeyshareData::Secp256k1(secp256k1_data) = &keyshare.data;
+    let KeyshareData::Secp256k1(secp256k1_data) = &keyshare.data else {
+        anyhow::bail!(
+            "Expected keyshare for legacy ECDSA domain, got {:?}",
+            keyshare.key_id.domain_id
+        );
+    };
     Ok(LegacyRootKeyshareData {
         epoch: keyshare.key_id.epoch_id.get(),
         private_share: secp256k1_data.private_share,

--- a/node/src/keyshare/test_utils.rs
+++ b/node/src/keyshare/test_utils.rs
@@ -1,6 +1,6 @@
 use super::permanent::PermanentKeyshareData;
 use super::{Keyshare, KeyshareData};
-use crate::providers::affine_point_to_public_key;
+use crate::providers::{ecdsa, eddsa};
 use crate::tests::TestGenerators;
 use cait_sith::ecdsa::KeygenOutput;
 use mpc_contract::primitives::domain::DomainId;
@@ -42,8 +42,11 @@ fn keyset_from_permanent_keyshare(permanent: &PermanentKeyshareData) -> Keyset {
         .iter()
         .map(|keyshare| {
             let key = match &keyshare.data {
-                KeyshareData::Secp256k1(secp256k1_data) => {
-                    affine_point_to_public_key(secp256k1_data.public_key).unwrap()
+                KeyshareData::Secp256k1(data) => {
+                    ecdsa::affine_point_to_public_key(data.public_key).unwrap()
+                }
+                KeyshareData::Ed25519(data) => {
+                    eddsa::convert_to_near_pubkey(&data.public_key_package).unwrap()
                 }
             };
             KeyForDomain {

--- a/node/src/mpc_client.rs
+++ b/node/src/mpc_client.rs
@@ -142,7 +142,7 @@ impl MpcClient {
                         // indexer is being shutdown. So just quit this task.
                         break;
                     };
-                    self.client.clone().update_indexer_height(block_update.block.height);
+                    self.client.update_indexer_height(block_update.block.height);
                     let signature_requests = block_update
                         .signature_requests
                         .into_iter()

--- a/node/src/providers/ecdsa/key_resharing.rs
+++ b/node/src/providers/ecdsa/key_resharing.rs
@@ -5,8 +5,7 @@ use crate::primitives::ParticipantId;
 use crate::protocol::run_protocol;
 use crate::providers::ecdsa::{EcdsaSignatureProvider, KeygenOutput};
 use cait_sith::protocol::Participant;
-use k256::elliptic_curve::sec1::FromEncodedPoint;
-use k256::{AffinePoint, EncodedPoint, Scalar, Secp256k1};
+use k256::{AffinePoint, Scalar, Secp256k1};
 
 impl EcdsaSignatureProvider {
     pub(super) async fn run_key_resharing_client_internal(
@@ -91,23 +90,6 @@ impl MpcLeaderCentricComputation<Scalar> for KeyResharingComputation {
     }
     fn leader_waits_for_success(&self) -> bool {
         false
-    }
-}
-
-pub fn public_key_to_affine_point(key: near_crypto::PublicKey) -> anyhow::Result<AffinePoint> {
-    match key {
-        near_crypto::PublicKey::SECP256K1(key) => {
-            let mut bytes = [0u8; 65];
-            bytes[0] = 0x04;
-            bytes[1..65].copy_from_slice(key.as_ref());
-            match Option::from(AffinePoint::from_encoded_point(&EncodedPoint::from_bytes(
-                bytes,
-            )?)) {
-                Some(result) => Ok(result),
-                None => anyhow::bail!("Failed to convert public key to affine point"),
-            }
-        }
-        _ => anyhow::bail!("Unsupported public key type"),
     }
 }
 

--- a/node/src/providers/ecdsa/presign.rs
+++ b/node/src/providers/ecdsa/presign.rs
@@ -121,9 +121,14 @@ impl EcdsaSignatureProvider {
         id: UniqueId,
         paired_triple_id: UniqueId,
     ) -> anyhow::Result<()> {
+        let keyshares = self.keyshares.values().cloned().collect::<Vec<_>>();
+        let [keyshare] = keyshares.as_slice() else {
+            anyhow::bail!("Expected only 1 share of ecdsa")
+        };
+
         FollowerPresignComputation {
             threshold: self.mpc_config.participants.threshold as usize,
-            keygen_out: self.keygen_output.clone(),
+            keygen_out: keyshare.clone(),
             triple_store: self.triple_store.clone(),
             paired_triple_id,
             out_presignature_store: self.presignature_store.clone(),

--- a/node/src/providers/mod.rs
+++ b/node/src/providers/mod.rs
@@ -13,7 +13,6 @@ use crate::config::ParticipantsConfig;
 use crate::network::NetworkTaskChannel;
 use crate::primitives::{MpcTaskId, ParticipantId};
 use crate::sign_request::SignatureId;
-pub use ecdsa::affine_point_to_public_key;
 pub use ecdsa::EcdsaSignatureProvider;
 pub use ecdsa::EcdsaTaskId;
 use std::sync::Arc;

--- a/node/src/sign_request.rs
+++ b/node/src/sign_request.rs
@@ -1,5 +1,6 @@
 use crate::db::{DBCol, SecretDB};
 use crate::metrics;
+use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::signature::{Payload, Tweak};
 use near_indexer_primitives::CryptoHash;
 use serde::{Deserialize, Serialize};
@@ -18,6 +19,7 @@ pub struct SignatureRequest {
     pub tweak: Tweak,
     pub entropy: [u8; 32],
     pub timestamp_nanosec: u64,
+    pub domain: DomainId,
 }
 
 pub struct SignRequestStorage {

--- a/node/src/signing/debug.rs
+++ b/node/src/signing/debug.rs
@@ -197,6 +197,7 @@ mod tests {
     use super::CompletedSignatureRequest;
     use crate::sign_request::SignatureRequest;
     use crate::signing::debug::CompletedSignatureRequests;
+    use mpc_contract::primitives::domain::DomainId;
     use mpc_contract::primitives::signature::{Payload, Tweak};
     use near_indexer_primitives::CryptoHash;
     use rand::seq::SliceRandom;
@@ -215,6 +216,7 @@ mod tests {
                     tweak: Tweak::new([0; 32]),
                     entropy: Default::default(),
                     timestamp_nanosec: Default::default(),
+                    domain: DomainId::legacy_ecdsa_id(),
                 },
                 progress: Default::default(),
                 indexed_block_height: i,

--- a/node/src/signing/queue.rs
+++ b/node/src/signing/queue.rs
@@ -443,6 +443,7 @@ mod tests {
     use crate::signing::recent_blocks_tracker::tests::TestBlockMaker;
     use crate::tests::TestGenerators;
     use crate::tracing::init_logging;
+    use mpc_contract::primitives::domain::DomainId;
     use mpc_contract::primitives::signature::{Payload, Tweak};
     use near_indexer_primitives::CryptoHash;
     use near_time::{Duration, FakeClock};
@@ -468,6 +469,7 @@ mod tests {
                 payload: Payload::from_legacy_ecdsa([0; 32]),
                 timestamp_nanosec: 0,
                 tweak: Tweak::new([0; 32]),
+                domain: DomainId::legacy_ecdsa_id(),
             };
             let leader_selection_order =
                 QueuedSignatureRequest::leader_selection_order(participants, request.id);


### PR DESCRIPTION
* Integrate Eddsa signature provider logic
* Make each signature provider store related keys. It's a questionable change. The other approach is to supply share when needed: when creating a signature, when setting-up background task, etc.. But for now it seems ok 

tests for eddsa will come in the follow-up PRs