### PR TITLE
Make multidomain and multi-signature-scheme fully work.

### DIFF
--- a/node/src/assets.rs
+++ b/node/src/assets.rs
@@ -3,6 +3,7 @@ use crate::primitives::ParticipantId;
 use anyhow::Context;
 use borsh::{BorshDeserialize, BorshSerialize};
 use futures::FutureExt;
+use mpc_contract::primitives::domain::DomainId;
 use near_time::Clock;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -443,6 +444,7 @@ where
 {
     db: Arc<SecretDB>,
     col: DBCol,
+    domain_id: Option<DomainId>,
     my_participant_id: ParticipantId,
     owned_queue: DoubleQueue<T, Vec<ParticipantId>>,
     last_id: Mutex<Option<UniqueId>>,
@@ -456,6 +458,7 @@ where
         clock: Clock,
         db: Arc<SecretDB>,
         col: DBCol,
+        domain_id: Option<DomainId>,
         my_participant_id: ParticipantId,
         condition: fn(&Vec<ParticipantId>, &T) -> bool,
         alive_participant_ids_query: Arc<dyn Fn() -> Vec<ParticipantId> + Send + Sync>,
@@ -466,15 +469,10 @@ where
         // but it's the simplest way to implement a multi-consumer, multi-producer queue that
         // supports asynchronous blocking when an asset isn't available.
         let mut last_id = None;
-        for item in db.iter_range(
-            col,
-            &UniqueId::prefix_for_participant_id(my_participant_id),
-            &UniqueId::prefix_for_participant_id(ParticipantId::from_raw(
-                my_participant_id.raw().checked_add(1).unwrap(),
-            )),
-        ) {
+        let (start, end) = Self::make_prefix_range(my_participant_id, domain_id);
+        for item in db.iter_range(col, &start, &end) {
             let (key, value) = item?;
-            let id = UniqueId::try_from_slice(&key)?;
+            let id = Self::decode_key(&key, domain_id)?;
             let value = serde_json::from_slice(&value)?;
             owned_queue.add_owned(id, value);
             last_id = Some(id);
@@ -483,10 +481,45 @@ where
         Ok(Self {
             db,
             col,
+            domain_id,
             my_participant_id,
             owned_queue,
             last_id: Mutex::new(last_id),
         })
+    }
+
+    fn make_prefix_range(
+        participant_id: ParticipantId,
+        domain_id: Option<DomainId>,
+    ) -> (Vec<u8>, Vec<u8>) {
+        let mut start = Vec::new();
+        let mut end = Vec::new();
+        if let Some(domain_id) = domain_id {
+            start.extend_from_slice(&domain_id.0.to_be_bytes());
+            end.extend_from_slice(&domain_id.0.to_be_bytes());
+        }
+        start.extend_from_slice(&UniqueId::prefix_for_participant_id(participant_id));
+        end.extend_from_slice(&UniqueId::prefix_for_participant_id(
+            ParticipantId::from_raw(participant_id.raw().checked_add(1).unwrap()),
+        ));
+        (start, end)
+    }
+
+    fn make_key(&self, id: UniqueId) -> Vec<u8> {
+        let mut key = Vec::new();
+        if let Some(domain_id) = self.domain_id {
+            key.extend_from_slice(&domain_id.0.to_be_bytes());
+        }
+        key.extend_from_slice(&borsh::to_vec(&id).unwrap());
+        key
+    }
+
+    fn decode_key(key: &[u8], domain_id: Option<DomainId>) -> anyhow::Result<UniqueId> {
+        let mut key = key;
+        if domain_id.is_some() {
+            key = &key[8..];
+        }
+        Ok(UniqueId::try_from_slice(key)?)
     }
 
     /// Generates an ID that won't conflict with existing ones, and reserves it
@@ -535,7 +568,7 @@ where
     pub async fn take_owned(&self) -> (UniqueId, T) {
         let (id, asset) = self.owned_queue.take_owned().await;
         let mut update = self.db.update();
-        update.delete(self.col, &borsh::to_vec(&id).unwrap());
+        update.delete(self.col, &self.make_key(id));
         update
             .commit()
             .expect("Unrecoverable error writing to database");
@@ -544,7 +577,7 @@ where
 
     /// Adds an owned asset to the storage.
     pub fn add_owned(&self, id: UniqueId, value: T) {
-        let key = borsh::to_vec(&id).unwrap();
+        let key = self.make_key(id);
         let value_ser = serde_json::to_vec(&value).unwrap();
         let mut update = self.db.update();
         update.put(self.col, &key, &value_ser);
@@ -559,6 +592,7 @@ where
     /// If any are found not to satisfy the current condition, they are discarded.
     /// Otherwise, they are kept aside as ready for immediate use.
     pub async fn maybe_discard_owned(&self, num_assets_to_process: usize) {
+        // TODO(#320): These should also be deleted from disk.
         self.owned_queue
             .maybe_discard_owned(num_assets_to_process)
             .await;
@@ -566,7 +600,7 @@ where
 
     /// Adds an unowned asset to the storage.
     pub fn add_unowned(&self, id: UniqueId, value: T) {
-        let key = borsh::to_vec(&id).unwrap();
+        let key = self.make_key(id);
         let value_ser = serde_json::to_vec(&value).unwrap();
         let mut update = self.db.update();
         update.put(self.col, &key, &value_ser);
@@ -578,7 +612,7 @@ where
     /// Removes an unowned asset from the storage and returns it. Returns
     /// an error if we do not have the asset in our database.
     pub fn take_unowned(&self, id: UniqueId) -> anyhow::Result<T> {
-        let key = borsh::to_vec(&id).unwrap();
+        let key = self.make_key(id);
         let value_ser = self.db.get(self.col, &key)?.ok_or_else(|| {
             anyhow::anyhow!("Unowned {} not found in the database: {:?}", self.col, id)
         })?;
@@ -593,7 +627,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{ColdQueue, DoubleQueue, UniqueId};
+    use super::{ColdQueue, DistributedAssetStorage, DomainId, DoubleQueue, UniqueId};
     use crate::async_testing::{run_future_once, MaybeReady};
     use crate::primitives::ParticipantId;
     use crate::providers::HasParticipants;
@@ -841,10 +875,11 @@ mod tests {
             ParticipantId::from_raw(3),
         ];
         let alive_participants = Arc::new(Mutex::new(all_participants.clone()));
-        let store = super::DistributedAssetStorage::<ParticipantsWithI32>::new(
+        let store = DistributedAssetStorage::<ParticipantsWithI32>::new(
             clock.clock(),
             db,
             crate::db::DBCol::Triple,
+            None,
             ParticipantId::from_raw(42),
             |cond, val| val.is_subset_of_active_participants(cond),
             {
@@ -975,10 +1010,11 @@ mod tests {
     fn test_distributed_store_add_take_owned() {
         let dir = tempfile::tempdir().unwrap();
         let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
-        let store = super::DistributedAssetStorage::<u32>::new(
+        let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
             crate::db::DBCol::Triple,
+            None,
             ParticipantId::from_raw(42),
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1021,10 +1057,11 @@ mod tests {
     fn test_distributed_store_add_owned_different_order() {
         let dir = tempfile::tempdir().unwrap();
         let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
-        let store = super::DistributedAssetStorage::<u32>::new(
+        let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db.clone(),
             crate::db::DBCol::Triple,
+            None,
             ParticipantId::from_raw(42),
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1070,10 +1107,11 @@ mod tests {
         // be based on the key. It doesn't have to be this way, but we test it
         // here just to clarify the current behavior.
         drop(store);
-        let store = super::DistributedAssetStorage::<u32>::new(
+        let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
             crate::db::DBCol::Triple,
+            None,
             ParticipantId::from_raw(42),
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1087,10 +1125,11 @@ mod tests {
     fn test_distribtued_store_add_take_unowned() {
         let dir = tempfile::tempdir().unwrap();
         let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
-        let store = super::DistributedAssetStorage::<u32>::new(
+        let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
             crate::db::DBCol::Triple,
+            None,
             ParticipantId::from_raw(42),
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1119,10 +1158,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
         let myself = ParticipantId::from_raw(42);
-        let store = super::DistributedAssetStorage::<u32>::new(
+        let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db.clone(),
             crate::db::DBCol::Triple,
+            None,
             myself,
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1142,10 +1182,11 @@ mod tests {
         store.add_unowned(UniqueId::new(other, 4, 0), 8);
 
         drop(store);
-        let store = super::DistributedAssetStorage::<u32>::new(
+        let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
             crate::db::DBCol::Triple,
+            None,
             myself,
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1167,5 +1208,73 @@ mod tests {
         );
 
         assert_eq!(store.take_unowned(UniqueId::new(other, 1, 0)).unwrap(), 5);
+    }
+
+    #[test]
+    fn test_multiple_domains() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let myself = ParticipantId::from_raw(42);
+        let other = ParticipantId::from_raw(43);
+
+        for i in 0..4 {
+            let domain_id = Some(DomainId(i));
+            let store = DistributedAssetStorage::<u64>::new(
+                FakeClock::default().clock(),
+                db.clone(),
+                crate::db::DBCol::Presignature,
+                domain_id,
+                myself,
+                |_, _| true,
+                Arc::new(std::vec::Vec::new),
+            )
+            .unwrap();
+
+            for j in 0..10 {
+                store.add_owned(UniqueId::new(myself, j, 0), 10000 + i * 100 + j);
+                store.add_unowned(UniqueId::new(other, j, 0), 20000 + i * 100 + j);
+            }
+            for j in 0..10 {
+                assert_eq!(
+                    store.take_owned().now_or_never().unwrap().1,
+                    10000 + i * 100 + j
+                );
+                assert_eq!(
+                    store.take_unowned(UniqueId::new(other, j, 0)).unwrap(),
+                    20000 + i * 100 + j
+                );
+            }
+            for j in 0..10 {
+                store.add_owned(UniqueId::new(myself, 100 + j, 0), 30000 + i * 100 + j);
+                store.add_unowned(UniqueId::new(other, 100 + j, 0), 40000 + i * 100 + j);
+            }
+        }
+
+        for i in 0..4 {
+            let domain_id = Some(DomainId(i));
+            let store = DistributedAssetStorage::<u64>::new(
+                FakeClock::default().clock(),
+                db.clone(),
+                crate::db::DBCol::Presignature,
+                domain_id,
+                myself,
+                |_, _| true,
+                Arc::new(std::vec::Vec::new),
+            )
+            .unwrap();
+
+            for j in 0..10 {
+                assert_eq!(
+                    store.take_owned().now_or_never().unwrap().1,
+                    30000 + i * 100 + j
+                );
+                assert_eq!(
+                    store
+                        .take_unowned(UniqueId::new(other, 100 + j, 0))
+                        .unwrap(),
+                    40000 + i * 100 + j
+                );
+            }
+        }
     }
 }

--- a/node/src/assets.rs
+++ b/node/src/assets.rs
@@ -517,7 +517,7 @@ where
     fn decode_key(key: &[u8], domain_id: Option<DomainId>) -> anyhow::Result<UniqueId> {
         let mut key = key;
         if domain_id.is_some() {
-            key = &key[8..];
+            key = &key[std::mem::size_of::<DomainId>()..];
         }
         Ok(UniqueId::try_from_slice(key)?)
     }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -190,7 +190,7 @@ impl StartCmd {
         .await?;
         let _web_server = tracking::spawn_checked("web server", web_server);
 
-        let secret_db = SecretDB::new(&home_dir, secrets.local_storage_aes_key)?;
+        let secret_db = SecretDB::new(&home_dir.join("assets"), secrets.local_storage_aes_key)?;
 
         let key_storage_config = KeyStorageConfig {
             home_dir: home_dir.clone(),

--- a/node/src/indexer/fake.rs
+++ b/node/src/indexer/fake.rs
@@ -149,16 +149,21 @@ impl FakeMpcContractState {
     }
 
     pub fn vote_abort_key_event(&mut self, account_id: AccountId, id: KeyEventId) {
+        self.env.set_signer(&account_id);
         match &mut self.state {
             ProtocolContractState::Initializing(state) => {
-                self.env.set_signer(&account_id);
+                if let Err(e) = state.vote_abort(id) {
+                    tracing::info!("vote_abort_key_event transaction failed: {}", e);
+                }
+            }
+            ProtocolContractState::Resharing(state) => {
                 if let Err(e) = state.vote_abort(id) {
                     tracing::info!("vote_abort_key_event transaction failed: {}", e);
                 }
             }
             _ => {
                 tracing::info!(
-                    "vote_abort_key_event transaction ignored because the contract is not in initializing state"
+                    "vote_abort_key_event transaction ignored because the contract is not in initializing or resharing state"
                 );
             }
         }

--- a/node/src/indexer/participants.rs
+++ b/node/src/indexer/participants.rs
@@ -106,8 +106,6 @@ pub struct ContractRunningState {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContractInitializingState {
-    // we also need the domain.wait
-    pub generated_keyset: Keyset,
     pub participants: ParticipantsConfig,
     pub key_event: ContractKeyEventInstance,
 }
@@ -141,10 +139,6 @@ impl ContractState {
             ProtocolContractState::NotInitialized => ContractState::Invalid,
             ProtocolContractState::Initializing(state) => {
                 ContractState::Initializing(ContractInitializingState {
-                    generated_keyset: Keyset {
-                        epoch_id: state.epoch_id,
-                        domains: state.generated_keys.clone(),
-                    },
                     participants: convert_participant_infos(
                         state.generating_key.proposed_parameters().clone(),
                         port_override,

--- a/node/src/indexer/types.rs
+++ b/node/src/indexer/types.rs
@@ -166,12 +166,11 @@ impl ChainRespondArgs {
                 .as_ecdsa()
                 .ok_or_else(|| anyhow::anyhow!("Payload is not an ECDSA payload"))?,
         )?;
-        let domain_id = DomainId::legacy_ecdsa_id();
         Ok(ChainRespondArgs {
             request: ChainSignatureRequest::new(
                 request.tweak.clone(),
                 request.payload.clone(),
-                domain_id,
+                request.domain,
             ),
             response: k256_signature_response(response.big_r, response.s, recovery_id)?,
         })

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -633,6 +633,7 @@ pub mod testing {
         pub const KEY_RESHARING_SIMPLE_TEST: Self = Self(5);
         pub const KEY_RESHARING_MULTISTAGE_TEST: Self = Self(6);
         pub const KEY_RESHARING_SIGNATURE_BUFFERING_TEST: Self = Self(7);
+        pub const BASIC_MULTIDOMAIN_TEST: Self = Self(8);
     }
 
     /// Converts a keypair to an ED25519 secret key, asserting that it is the

--- a/node/src/protocol_version.rs
+++ b/node/src/protocol_version.rs
@@ -14,4 +14,4 @@
 /// an incompatible protocol change, we are effectively creating a new network
 /// that is separate from the old network, thus requiring only threshold number
 /// of nodes to upgrade.
-pub const MPC_PROTOCOL_VERSION: u32 = 3;
+pub const MPC_PROTOCOL_VERSION: u32 = 4;

--- a/node/src/tests/basic_cluster.rs
+++ b/node/src/tests/basic_cluster.rs
@@ -26,13 +26,16 @@ async fn test_basic_cluster() {
         TXN_DELAY_BLOCKS,
         PortSeed::BASIC_CLUSTER_TEST,
     );
+
+    let domain = DomainConfig {
+        id: DomainId(0),
+        scheme: SignatureScheme::Secp256k1,
+    };
+
     {
         let mut contract = setup.indexer.contract_mut().await;
-        contract.initialize(setup.participants);
-        contract.add_domains(vec![DomainConfig {
-            id: DomainId(0),
-            scheme: SignatureScheme::Secp256k1,
-        }]);
+        contract.initialize(setup.participants.clone());
+        contract.add_domains(vec![domain.clone()]);
     }
 
     let _runs = setup
@@ -44,6 +47,7 @@ async fn test_basic_cluster() {
     assert!(request_signature_and_await_response(
         &mut setup.indexer,
         "user0",
+        &domain,
         std::time::Duration::from_secs(60)
     )
     .await

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -21,13 +21,13 @@ use crate::web::start_web_server;
 use cait_sith::ecdsa::presign::PresignArguments;
 use cait_sith::ecdsa::sign::FullSignature;
 use cait_sith::{ecdsa, eddsa};
-use mpc_contract::primitives::domain::DomainId;
-use mpc_contract::primitives::signature::Payload;
+use mpc_contract::primitives::domain::{DomainConfig, SignatureScheme};
+use mpc_contract::primitives::signature::{Bytes, Payload};
 use near_indexer_primitives::types::Finality;
 use near_indexer_primitives::CryptoHash;
 use near_sdk::AccountId;
 use near_time::Clock;
-use rand::RngCore;
+use rand::{Rng, RngCore};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::time::timeout;
@@ -35,6 +35,7 @@ use tokio::time::timeout;
 mod basic_cluster;
 mod benchmark;
 mod faulty;
+mod multidomain;
 mod research;
 mod resharing;
 
@@ -327,10 +328,22 @@ impl IntegrationTestSetup {
 pub async fn request_signature_and_await_response(
     indexer: &mut FakeIndexerManager,
     user: &str,
+    domain: &DomainConfig,
     timeout_sec: std::time::Duration,
 ) -> Option<std::time::Duration> {
-    let mut payload = [0; 32];
-    rand::thread_rng().fill_bytes(payload.as_mut());
+    let payload = match domain.scheme {
+        SignatureScheme::Secp256k1 => {
+            let mut payload = [0; 32];
+            rand::thread_rng().fill_bytes(payload.as_mut());
+            Payload::Ecdsa(Bytes::new(payload.to_vec()).unwrap())
+        }
+        SignatureScheme::Ed25519 => {
+            let len = rand::thread_rng().gen_range(32..1232);
+            let mut payload = vec![0; len];
+            rand::thread_rng().fill_bytes(payload.as_mut());
+            Payload::Eddsa(Bytes::new(payload.to_vec()).unwrap())
+        }
+    };
     let request = SignatureRequestFromChain {
         entropy: rand::random(),
         signature_id: CryptoHash(rand::random()),
@@ -338,9 +351,9 @@ pub async fn request_signature_and_await_response(
         predecessor_id: user.parse().unwrap(),
         timestamp_nanosec: rand::random(),
         request: SignArgs {
-            domain_id: DomainId::legacy_ecdsa_id(),
+            domain_id: domain.id,
             path: "m/44'/60'/0'/0/0".to_string(),
-            payload: Payload::from_legacy_ecdsa(payload),
+            payload,
         },
     };
     tracing::info!(
@@ -364,6 +377,16 @@ pub async fn request_signature_and_await_response(
                         user,
                         request.request.payload,
                         signature.request.payload
+                    );
+                    continue;
+                }
+                if signature.request.domain_id != domain.id {
+                    tracing::info!(
+                        "Received signature is not for the domain we requested (user {})
+                         Expected {:?}, actual {:?}",
+                        user,
+                        domain.id,
+                        signature.request.domain_id
                     );
                     continue;
                 }

--- a/node/src/tests/multidomain.rs
+++ b/node/src/tests/multidomain.rs
@@ -1,0 +1,106 @@
+use crate::p2p::testing::PortSeed;
+use crate::tests::{request_signature_and_await_response, IntegrationTestSetup};
+use crate::tracking::AutoAbortTask;
+use mpc_contract::primitives::domain::{DomainConfig, DomainId, SignatureScheme};
+use near_o11y::testonly::init_integration_logger;
+use near_time::Clock;
+use serial_test::serial;
+
+// Make a cluster of four nodes, test that we can generate keyshares
+// and then produce signatures.
+#[tokio::test]
+#[serial]
+async fn test_basic_multidomain() {
+    init_integration_logger();
+    const NUM_PARTICIPANTS: usize = 4;
+    const THRESHOLD: usize = 3;
+    const TXN_DELAY_BLOCKS: u64 = 1;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut setup = IntegrationTestSetup::new(
+        Clock::real(),
+        temp_dir.path(),
+        (0..NUM_PARTICIPANTS)
+            .map(|i| format!("test{}", i).parse().unwrap())
+            .collect(),
+        THRESHOLD,
+        TXN_DELAY_BLOCKS,
+        PortSeed::BASIC_MULTIDOMAIN_TEST,
+    );
+
+    let mut domains = vec![
+        DomainConfig {
+            id: DomainId(0),
+            scheme: SignatureScheme::Secp256k1,
+        },
+        DomainConfig {
+            id: DomainId(1),
+            scheme: SignatureScheme::Ed25519,
+        },
+    ];
+
+    {
+        let mut contract = setup.indexer.contract_mut().await;
+        contract.initialize(setup.participants.clone());
+        contract.add_domains(domains.clone());
+    }
+
+    let _runs = setup
+        .configs
+        .into_iter()
+        .map(|config| AutoAbortTask::from(tokio::spawn(config.run())))
+        .collect::<Vec<_>>();
+
+    for domain in &domains {
+        assert!(request_signature_and_await_response(
+            &mut setup.indexer,
+            &format!("user{}", domain.id.0),
+            domain,
+            std::time::Duration::from_secs(60)
+        )
+        .await
+        .is_some());
+    }
+
+    {
+        let new_domains = vec![
+            DomainConfig {
+                id: DomainId(2),
+                scheme: SignatureScheme::Ed25519,
+            },
+            DomainConfig {
+                id: DomainId(3),
+                scheme: SignatureScheme::Secp256k1,
+            },
+        ];
+        let mut contract = setup.indexer.contract_mut().await;
+        contract.add_domains(new_domains.clone());
+        domains.extend(new_domains);
+    }
+
+    for domain in &domains {
+        assert!(request_signature_and_await_response(
+            &mut setup.indexer,
+            &format!("user{}", domain.id.0),
+            domain,
+            std::time::Duration::from_secs(60)
+        )
+        .await
+        .is_some());
+    }
+
+    {
+        let mut contract = setup.indexer.contract_mut().await;
+        contract.start_resharing(setup.participants);
+    }
+
+    for domain in &domains {
+        assert!(request_signature_and_await_response(
+            &mut setup.indexer,
+            &format!("user{}", domain.id.0),
+            domain,
+            std::time::Duration::from_secs(60)
+        )
+        .await
+        .is_some());
+    }
+}

--- a/node/src/tests/resharing.rs
+++ b/node/src/tests/resharing.rs
@@ -33,13 +33,15 @@ async fn test_key_resharing_simple() {
     let mut initial_participants = setup.participants.clone();
     initial_participants.participants.pop();
 
+    let domain = DomainConfig {
+        id: DomainId(0),
+        scheme: SignatureScheme::Secp256k1,
+    };
+
     {
         let mut contract = setup.indexer.contract_mut().await;
         contract.initialize(setup.participants.clone());
-        contract.add_domains(vec![DomainConfig {
-            id: DomainId(0),
-            scheme: SignatureScheme::Secp256k1,
-        }]);
+        contract.add_domains(vec![domain.clone()]);
     }
 
     let _runs = setup
@@ -52,6 +54,7 @@ async fn test_key_resharing_simple() {
     assert!(request_signature_and_await_response(
         &mut setup.indexer,
         "user0",
+        &domain,
         std::time::Duration::from_secs(60)
     )
     .await
@@ -79,6 +82,7 @@ async fn test_key_resharing_simple() {
     assert!(request_signature_and_await_response(
         &mut setup.indexer,
         "user1",
+        &domain,
         std::time::Duration::from_secs(60)
     )
     .await
@@ -111,13 +115,15 @@ async fn test_key_resharing_multistage() {
     participants_1.participants.pop();
     participants_1.threshold = 3;
 
+    let domain = DomainConfig {
+        id: DomainId(0),
+        scheme: SignatureScheme::Secp256k1,
+    };
+
     {
         let mut contract = setup.indexer.contract_mut().await;
         contract.initialize(setup.participants.clone());
-        contract.add_domains(vec![DomainConfig {
-            id: DomainId(0),
-            scheme: SignatureScheme::Secp256k1,
-        }]);
+        contract.add_domains(vec![domain.clone()]);
     }
 
     let _runs = setup
@@ -130,6 +136,7 @@ async fn test_key_resharing_multistage() {
     assert!(request_signature_and_await_response(
         &mut setup.indexer,
         "user0",
+        &domain,
         std::time::Duration::from_secs(60)
     )
     .await
@@ -161,6 +168,7 @@ async fn test_key_resharing_multistage() {
     assert!(request_signature_and_await_response(
         &mut setup.indexer,
         "user1",
+        &domain,
         std::time::Duration::from_secs(60)
     )
     .await
@@ -188,6 +196,7 @@ async fn test_key_resharing_multistage() {
     assert!(request_signature_and_await_response(
         &mut setup.indexer,
         "user2",
+        &domain,
         std::time::Duration::from_secs(60)
     )
     .await
@@ -219,6 +228,7 @@ async fn test_key_resharing_multistage() {
     assert!(request_signature_and_await_response(
         &mut setup.indexer,
         "user1",
+        &domain,
         std::time::Duration::from_secs(60)
     )
     .await
@@ -251,6 +261,7 @@ async fn test_key_resharing_multistage() {
     assert!(request_signature_and_await_response(
         &mut setup.indexer,
         "user1",
+        &domain,
         std::time::Duration::from_secs(60)
     )
     .await
@@ -281,13 +292,15 @@ async fn test_key_resharing_signature_buffering() {
     let mut initial_participants = setup.participants.clone();
     initial_participants.participants.pop();
 
+    let domain = DomainConfig {
+        id: DomainId(0),
+        scheme: SignatureScheme::Secp256k1,
+    };
+
     {
         let mut contract = setup.indexer.contract_mut().await;
         contract.initialize(setup.participants.clone());
-        contract.add_domains(vec![DomainConfig {
-            id: DomainId(0),
-            scheme: SignatureScheme::Secp256k1,
-        }]);
+        contract.add_domains(vec![domain.clone()]);
     }
 
     let _runs = setup
@@ -299,6 +312,7 @@ async fn test_key_resharing_signature_buffering() {
     let response_time = request_signature_and_await_response(
         &mut setup.indexer,
         "user0",
+        &domain,
         std::time::Duration::from_secs(60),
     )
     .await
@@ -341,11 +355,14 @@ async fn test_key_resharing_signature_buffering() {
     }
 
     // Send a request for signature. This should timeout.
-    assert!(
-        request_signature_and_await_response(&mut setup.indexer, "user1", response_time * 2)
-            .await
-            .is_none()
-    );
+    assert!(request_signature_and_await_response(
+        &mut setup.indexer,
+        "user1",
+        &domain,
+        response_time * 2
+    )
+    .await
+    .is_none());
 
     // Re-enable the node. Now we should get the signature response.
     drop(disabled);


### PR DESCRIPTION
Inspired by @kuksag 's refactoring to put multiple domains into each signature provider, this goes all the way to make multidomain just work.

* Split presignature storage across domains by prefixing it by the `DomainId`. Add new test in the storage layer to check its behavior. Closes #287 .
* Make ecdsa signature provider have multiple presignature storages, one for each domain, and a corresponding background presignature generation task for each domain.
* Add `domain_id` to Presignature MpcTaskId. Bump protocol version since this is a network incompatible change.
* Fix #248 in the meantime, since the new store is no longer compatible with the old anyway. Also closes #312 since we'll start with empty DB.
* Fix a bug that the resharing computation was being passed an incorrect DomainConfig (the stale one from the ContractResharingState). Refactor the code around it to make that stale KeyEvent no longer available in the resharing job so we don't accidentally pass it in in the future.
* Add a `test_basic_multidomain` integration test to check both ecdsa and eddsa with two domains each, doing keygen, resharing, and signing.

Closes #298 since this implements multidomain support.