### PR TITLE
Cait-sith follow-up refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/kuksag/cait-sith?rev=5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5#5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5"
+source = "git+https://github.com/Near-One/cait-sith?rev=5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5#5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5"
 dependencies = [
  "auto_ops",
  "ck-meow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/kuksag/cait-sith?rev=b61d5969fb33b0c9eb4e41f9224cee41fe48a6b5#b61d5969fb33b0c9eb4e41f9224cee41fe48a6b5"
+source = "git+https://github.com/kuksag/cait-sith?rev=5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5#5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5"
 dependencies = [
  "auto_ops",
  "ck-meow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/Near-One/cait-sith?rev=27b9ae1ae394ad9d8f40e75a5fbab46242409165#27b9ae1ae394ad9d8f40e75a5fbab46242409165"
+source = "git+https://github.com/kuksag/cait-sith?rev=b61d5969fb33b0c9eb4e41f9224cee41fe48a6b5#b61d5969fb33b0c9eb4e41f9224cee41fe48a6b5"
 dependencies = [
  "auto_ops",
  "ck-meow",
@@ -3938,7 +3938,6 @@ dependencies = [
  "curve25519-dalek",
  "deranged",
  "flume",
- "frost-ed25519",
  "futures",
  "futures-util",
  "gcloud-sdk",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.92"
 async-trait = "0.1.83"
 axum = "0.7.9"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/kuksag/cait-sith", rev = "5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5", features = ["k256"] }
+cait-sith = { git = "https://github.com/Near-One/cait-sith", rev = "5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5", features = ["k256"] }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.92"
 async-trait = "0.1.83"
 axum = "0.7.9"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/kuksag/cait-sith", rev = "b61d5969fb33b0c9eb4e41f9224cee41fe48a6b5", features = ["k256"] }
+cait-sith = { git = "https://github.com/kuksag/cait-sith", rev = "5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5", features = ["k256"] }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.92"
 async-trait = "0.1.83"
 axum = "0.7.9"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/Near-One/cait-sith", rev = "27b9ae1ae394ad9d8f40e75a5fbab46242409165" }
+cait-sith = { git = "https://github.com/kuksag/cait-sith", rev = "b61d5969fb33b0c9eb4e41f9224cee41fe48a6b5", features = ["k256"] }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"
@@ -47,7 +47,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2"
 x509-parser = "0.16.0"
 
-frost-ed25519 = "2.1.0"
 curve25519-dalek = "4.1.3"
 
 near-indexer = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -447,11 +447,12 @@ mod tests {
     fn create_test_keyshare() -> LegacyRootKeyshareData {
         // Create a dummy private key - this is only for testing
         let private_share = Scalar::ONE;
-        let public_key = AffinePoint::default();
+        // Do some computation to get non-identity public key
+        let public_key = AffinePoint::GENERATOR * private_share;
         LegacyRootKeyshareData {
             epoch: 1,
             private_share,
-            public_key,
+            public_key: public_key.to_affine(),
         }
     }
 

--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -22,7 +22,6 @@ use crate::web::SignatureDebugRequest;
 use cait_sith::{ecdsa, eddsa};
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use k256::Secp256k1;
 use mpc_contract::primitives::domain::{DomainId, SignatureScheme};
 use near_time::Clock;
 use std::collections::HashMap;
@@ -309,7 +308,6 @@ impl Coordinator {
                 key_event_receiver,
                 chain_txn_sender,
                 mpc_config.participants.threshold as usize,
-                contract_state.key_event.domain,
             )
             .await?;
         } else {
@@ -382,7 +380,7 @@ impl Coordinator {
 
         let sign_request_store = Arc::new(SignRequestStorage::new(secret_db.clone())?);
 
-        let mut ecdsa_keyshares: HashMap<DomainId, ecdsa::KeygenOutput<Secp256k1>> = HashMap::new();
+        let mut ecdsa_keyshares: HashMap<DomainId, ecdsa::KeygenOutput> = HashMap::new();
         let mut eddsa_keyshares: HashMap<DomainId, eddsa::KeygenOutput> = HashMap::new();
         let mut domain_to_scheme: HashMap<DomainId, SignatureScheme> = HashMap::new();
 

--- a/node/src/key_events.rs
+++ b/node/src/key_events.rs
@@ -52,13 +52,13 @@ pub async fn keygen_computation_inner(
         SignatureScheme::Secp256k1 => {
             let keyshare =
                 EcdsaSignatureProvider::run_key_generation_client(threshold, channel).await?;
-            let public_key = keyshare.public_key.to_near_crypto()?;
+            let public_key = keyshare.public_key.to_near_public_key()?;
             (KeyshareData::Secp256k1(keyshare), public_key)
         }
         SignatureScheme::Ed25519 => {
             let keyshare =
                 EddsaSignatureProvider::run_key_generation_client(threshold, channel).await?;
-            let public_key = keyshare.public_key.to_near_crypto()?;
+            let public_key = keyshare.public_key.to_near_public_key()?;
             (KeyshareData::Ed25519(keyshare), public_key)
         }
     };

--- a/node/src/keyshare/compat.rs
+++ b/node/src/keyshare/compat.rs
@@ -1,6 +1,8 @@
 use super::permanent::LegacyRootKeyshareData;
 use super::{Keyshare, KeyshareData};
 use cait_sith::ecdsa::KeygenOutput;
+use cait_sith::frost_core::keys::SigningShare;
+use cait_sith::frost_secp256k1::VerifyingKey;
 use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::key_state::{AttemptId, EpochId, KeyEventId};
 
@@ -27,8 +29,8 @@ pub fn legacy_ecdsa_key_from_keyshares(
     };
     Ok(LegacyRootKeyshareData {
         epoch: keyshare.key_id.epoch_id.get(),
-        private_share: secp256k1_data.private_share,
-        public_key: secp256k1_data.public_key,
+        private_share: secp256k1_data.private_share.to_scalar(),
+        public_key: secp256k1_data.public_key.to_element().to_affine(),
     })
 }
 
@@ -42,8 +44,8 @@ impl Keyshare {
                 AttemptId::legacy_attempt_id(),
             ),
             data: KeyshareData::Secp256k1(KeygenOutput {
-                private_share: legacy.private_share,
-                public_key: legacy.public_key,
+                private_share: SigningShare::new(legacy.private_share),
+                public_key: VerifyingKey::new(legacy.public_key.into()),
             }),
         }
     }

--- a/node/src/keyshare/mod.rs
+++ b/node/src/keyshare/mod.rs
@@ -30,8 +30,8 @@ pub struct Keyshare {
 impl Keyshare {
     pub fn public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
         let public_key = match &self.data {
-            KeyshareData::Secp256k1(data) => data.public_key.to_near_crypto()?,
-            KeyshareData::Ed25519(data) => data.public_key.to_near_crypto()?,
+            KeyshareData::Secp256k1(data) => data.public_key.to_near_public_key()?,
+            KeyshareData::Ed25519(data) => data.public_key.to_near_public_key()?,
         };
         Ok(public_key.to_string().parse()?)
     }

--- a/node/src/keyshare/mod.rs
+++ b/node/src/keyshare/mod.rs
@@ -6,36 +6,19 @@ mod temporary;
 #[cfg(test)]
 pub mod test_utils;
 
-use crate::providers::{ecdsa, eddsa};
+use crate::providers::PublicKeyConversion;
 use anyhow::Context;
-use k256::Secp256k1;
 use mpc_contract::primitives::key_state::Keyset;
 use mpc_contract::primitives::key_state::{EpochId, KeyEventId, KeyForDomain};
 use permanent::{PermanentKeyStorage, PermanentKeyStorageBackend, PermanentKeyshareData};
 use serde::{Deserialize, Serialize};
 use temporary::{PendingKeyshareStorageHandle, TemporaryKeyStorage};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub enum KeyshareData {
-    Secp256k1(cait_sith::ecdsa::KeygenOutput<Secp256k1>),
+    Secp256k1(cait_sith::ecdsa::KeygenOutput),
     Ed25519(cait_sith::eddsa::KeygenOutput),
 }
-
-impl PartialEq for KeyshareData {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (KeyshareData::Secp256k1(a), KeyshareData::Secp256k1(b)) => {
-                a.private_share == b.private_share && a.public_key == b.public_key
-            }
-            (KeyshareData::Ed25519(a), KeyshareData::Ed25519(b)) => {
-                a.private_share == b.private_share && a.public_key_package == b.public_key_package
-            }
-            _ => false,
-        }
-    }
-}
-
-impl Eq for KeyshareData {}
 
 /// A single keyshare, corresponding to one epoch, one domain, one attempt.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -47,12 +30,8 @@ pub struct Keyshare {
 impl Keyshare {
     pub fn public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
         let public_key = match &self.data {
-            KeyshareData::Secp256k1(secp256k1_data) => {
-                ecdsa::affine_point_to_public_key(secp256k1_data.public_key)?
-            }
-            KeyshareData::Ed25519(ed25519_data) => {
-                eddsa::convert_to_near_pubkey(&ed25519_data.public_key_package)?
-            }
+            KeyshareData::Secp256k1(data) => data.public_key.to_near_crypto()?,
+            KeyshareData::Ed25519(data) => data.public_key.to_near_crypto()?,
         };
         Ok(public_key.to_string().parse()?)
     }

--- a/node/src/keyshare/test_utils.rs
+++ b/node/src/keyshare/test_utils.rs
@@ -1,6 +1,6 @@
 use super::permanent::PermanentKeyshareData;
 use super::{Keyshare, KeyshareData};
-use crate::providers::{ecdsa, eddsa};
+use crate::providers::PublicKeyConversion;
 use crate::tests::TestGenerators;
 use cait_sith::ecdsa::KeygenOutput;
 use mpc_contract::primitives::domain::DomainId;
@@ -42,12 +42,8 @@ fn keyset_from_permanent_keyshare(permanent: &PermanentKeyshareData) -> Keyset {
         .iter()
         .map(|keyshare| {
             let key = match &keyshare.data {
-                KeyshareData::Secp256k1(data) => {
-                    ecdsa::affine_point_to_public_key(data.public_key).unwrap()
-                }
-                KeyshareData::Ed25519(data) => {
-                    eddsa::convert_to_near_pubkey(&data.public_key_package).unwrap()
-                }
+                KeyshareData::Secp256k1(data) => data.public_key.to_near_crypto().unwrap(),
+                KeyshareData::Ed25519(data) => data.public_key.to_near_crypto().unwrap(),
             };
             KeyForDomain {
                 domain_id: keyshare.key_id.domain_id,

--- a/node/src/keyshare/test_utils.rs
+++ b/node/src/keyshare/test_utils.rs
@@ -42,8 +42,8 @@ fn keyset_from_permanent_keyshare(permanent: &PermanentKeyshareData) -> Keyset {
         .iter()
         .map(|keyshare| {
             let key = match &keyshare.data {
-                KeyshareData::Secp256k1(data) => data.public_key.to_near_crypto().unwrap(),
-                KeyshareData::Ed25519(data) => data.public_key.to_near_crypto().unwrap(),
+                KeyshareData::Secp256k1(data) => data.public_key.to_near_public_key().unwrap(),
+                KeyshareData::Ed25519(data) => data.public_key.to_near_public_key().unwrap(),
             };
             KeyForDomain {
                 domain_id: keyshare.key_id.domain_id,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 use clap::Parser;
 use tracing::init_logging;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 use clap::Parser;
 use tracing::init_logging;
 

--- a/node/src/providers/ecdsa/key_generation.rs
+++ b/node/src/providers/ecdsa/key_generation.rs
@@ -3,13 +3,12 @@ use crate::network::NetworkTaskChannel;
 use crate::protocol::run_protocol;
 use crate::providers::ecdsa::{EcdsaSignatureProvider, KeygenOutput};
 use cait_sith::protocol::Participant;
-use k256::Secp256k1;
 
 impl EcdsaSignatureProvider {
     pub(super) async fn run_key_generation_client_internal(
         threshold: usize,
         channel: NetworkTaskChannel,
-    ) -> anyhow::Result<KeygenOutput<Secp256k1>> {
+    ) -> anyhow::Result<KeygenOutput> {
         let key = KeyGenerationComputation { threshold }
             .perform_leader_centric_computation(
                 channel,
@@ -30,11 +29,8 @@ pub struct KeyGenerationComputation {
 }
 
 #[async_trait::async_trait]
-impl MpcLeaderCentricComputation<KeygenOutput<Secp256k1>> for KeyGenerationComputation {
-    async fn compute(
-        self,
-        channel: &mut NetworkTaskChannel,
-    ) -> anyhow::Result<KeygenOutput<Secp256k1>> {
+impl MpcLeaderCentricComputation<KeygenOutput> for KeyGenerationComputation {
+    async fn compute(self, channel: &mut NetworkTaskChannel) -> anyhow::Result<KeygenOutput> {
         let cs_participants = channel
             .participants()
             .iter()
@@ -61,7 +57,6 @@ mod tests {
     use crate::providers::ecdsa::{EcdsaTaskId, KeygenOutput};
     use crate::tests::TestGenerators;
     use crate::tracking::testing::start_root_task_with_periodic_dump;
-    use k256::Secp256k1;
     use mpc_contract::primitives::domain::DomainId;
     use mpc_contract::primitives::key_state::{AttemptId, EpochId, KeyEventId};
     use std::sync::Arc;
@@ -84,7 +79,7 @@ mod tests {
     async fn run_keygen_client(
         client: Arc<MeshNetworkClient>,
         mut channel_receiver: mpsc::UnboundedReceiver<NetworkTaskChannel>,
-    ) -> anyhow::Result<KeygenOutput<Secp256k1>> {
+    ) -> anyhow::Result<KeygenOutput> {
         let participant_id = client.my_participant_id();
         let all_participant_ids = client.all_participant_ids();
         // We'll have the first participant be the leader.

--- a/node/src/providers/ecdsa/mod.rs
+++ b/node/src/providers/ecdsa/mod.rs
@@ -5,7 +5,6 @@ mod sign;
 use mpc_contract::primitives::key_state::KeyEventId;
 pub use presign::PresignatureStorage;
 use std::collections::HashMap;
-use std::str::FromStr;
 mod kdf;
 pub mod key_resharing;
 pub mod triple;
@@ -17,15 +16,17 @@ use crate::config::{ConfigFile, MpcConfig, ParticipantsConfig};
 use crate::db::SecretDB;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::MpcTaskId;
-use crate::providers::SignatureProvider;
+use crate::providers::{PublicKeyConversion, SignatureProvider};
 use crate::sign_request::{SignRequestStorage, SignatureId};
 use crate::tracking;
 use anyhow::Context;
 use borsh::{BorshDeserialize, BorshSerialize};
 use cait_sith::ecdsa::sign::FullSignature;
 use cait_sith::ecdsa::KeygenOutput;
+use cait_sith::frost_secp256k1::keys::SigningShare;
+use cait_sith::frost_secp256k1::VerifyingKey;
 use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use k256::{AffinePoint, EncodedPoint, Scalar, Secp256k1};
+use k256::{AffinePoint, EncodedPoint, Secp256k1};
 use mpc_contract::primitives::domain::DomainId;
 use near_time::Clock;
 use std::sync::Arc;
@@ -41,7 +42,7 @@ pub struct EcdsaSignatureProvider {
 
 #[derive(Clone)]
 pub(super) struct PerDomainData {
-    pub keyshare: KeygenOutput<Secp256k1>,
+    pub keyshare: KeygenOutput,
     pub presignature_store: Arc<PresignatureStorage>,
 }
 
@@ -53,7 +54,7 @@ impl EcdsaSignatureProvider {
         clock: Clock,
         db: Arc<SecretDB>,
         sign_request_store: Arc<SignRequestStorage>,
-        keyshares: HashMap<DomainId, KeygenOutput<Secp256k1>>,
+        keyshares: HashMap<DomainId, KeygenOutput>,
     ) -> anyhow::Result<Self> {
         let active_participants_query = {
             let network_client = client.clone();
@@ -133,16 +134,16 @@ impl From<EcdsaTaskId> for MpcTaskId {
 }
 
 impl SignatureProvider for EcdsaSignatureProvider {
-    type PublicKey = AffinePoint;
-    type SecretShare = Scalar;
-    type KeygenOutput = KeygenOutput<Secp256k1>;
-    type SignatureOutput = (FullSignature<Secp256k1>, AffinePoint);
+    type PublicKey = VerifyingKey;
+    type SecretShare = SigningShare;
+    type KeygenOutput = KeygenOutput;
+    type Signature = FullSignature<Secp256k1>;
     type TaskId = EcdsaTaskId;
 
     async fn make_signature(
         self: Arc<Self>,
         id: SignatureId,
-    ) -> anyhow::Result<Self::SignatureOutput> {
+    ) -> anyhow::Result<(Self::Signature, Self::PublicKey)> {
         self.make_signature_leader(id).await
     }
 
@@ -155,8 +156,8 @@ impl SignatureProvider for EcdsaSignatureProvider {
 
     async fn run_key_resharing_client(
         new_threshold: usize,
-        my_share: Option<Scalar>,
-        public_key: AffinePoint,
+        my_share: Option<SigningShare>,
+        public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
@@ -252,33 +253,53 @@ impl SignatureProvider for EcdsaSignatureProvider {
     }
 }
 
-pub fn affine_point_to_public_key(point: AffinePoint) -> anyhow::Result<near_crypto::PublicKey> {
-    Ok(near_crypto::PublicKey::SECP256K1(
-        near_crypto::Secp256K1PublicKey::try_from(&point.to_encoded_point(false).as_bytes()[1..65])
-            .context("Failed to convert affine point to public key")?,
-    ))
-}
+impl PublicKeyConversion for VerifyingKey {
+    fn to_near_crypto(&self) -> anyhow::Result<near_crypto::PublicKey> {
+        let bytes = self.to_element().to_encoded_point(false).to_bytes();
+        anyhow::ensure!(bytes[0] == 0x04);
+        Ok(near_crypto::PublicKey::SECP256K1(
+            near_crypto::Secp256K1PublicKey::try_from(&bytes[1..65])
+                .context("Failed to convert public key to near crypto type")?,
+        ))
+    }
 
-pub fn public_key_to_affine_point(key: near_crypto::PublicKey) -> anyhow::Result<AffinePoint> {
-    match key {
-        near_crypto::PublicKey::SECP256K1(key) => {
-            let mut bytes = [0u8; 65];
-            bytes[0] = 0x04;
-            bytes[1..65].copy_from_slice(key.as_ref());
-            match Option::from(AffinePoint::from_encoded_point(&EncodedPoint::from_bytes(
-                bytes,
-            )?)) {
-                Some(result) => Ok(result),
-                None => anyhow::bail!("Failed to convert public key to affine point"),
+    fn from_near_crypto(public_key: &near_crypto::PublicKey) -> anyhow::Result<Self> {
+        match public_key {
+            near_crypto::PublicKey::SECP256K1(key) => {
+                let mut bytes = [0u8; 65];
+                bytes[0] = 0x04;
+                bytes[1..65].copy_from_slice(key.as_ref());
+
+                let encoded_point = EncodedPoint::from_bytes(bytes)?;
+                let affine_point = AffinePoint::from_encoded_point(&encoded_point)
+                    .into_option()
+                    .ok_or(anyhow::anyhow!(
+                        "Failed to convert encoded point to affine point"
+                    ))?;
+                Ok(VerifyingKey::new(affine_point.into()))
             }
+            _ => anyhow::bail!("Unsupported public key type"),
         }
-        _ => anyhow::bail!("Unsupported public key type"),
     }
 }
 
-pub fn sdk_public_key_to_affine_point(
-    public_key: &near_sdk::PublicKey,
-) -> anyhow::Result<AffinePoint> {
-    let public_key = near_crypto::PublicKey::from_str(&String::from(public_key));
-    public_key_to_affine_point(public_key?)
+#[test]
+fn check_pubkey_conversion_to_sdk() -> anyhow::Result<()> {
+    use crate::tests::TestGenerators;
+    let x = TestGenerators::new(4, 3)
+        .make_ecdsa_keygens()
+        .values()
+        .next()
+        .unwrap()
+        .clone();
+    x.public_key.to_near_crypto()?;
+    Ok(())
+}
+
+#[test]
+fn check_conversion_from_sdk() -> anyhow::Result<()> {
+    let near_sdk: near_sdk::PublicKey = "secp256k1:5TJSTQwYwe3MgTCep9DbLxLT6UjB6LFn3SStpBMgdfGjBopNjxL7mpNK92R6cdyByjz7vUQdRgtLiu9w84kopNqn"
+                .parse()?;
+    let _ = VerifyingKey::from_near_sdk(&near_sdk)?;
+    Ok(())
 }

--- a/node/src/providers/ecdsa/mod.rs
+++ b/node/src/providers/ecdsa/mod.rs
@@ -254,7 +254,7 @@ impl SignatureProvider for EcdsaSignatureProvider {
 }
 
 impl PublicKeyConversion for VerifyingKey {
-    fn to_near_crypto(&self) -> anyhow::Result<near_crypto::PublicKey> {
+    fn to_near_public_key(&self) -> anyhow::Result<near_crypto::PublicKey> {
         let bytes = self.to_element().to_encoded_point(false).to_bytes();
         anyhow::ensure!(bytes[0] == 0x04);
         Ok(near_crypto::PublicKey::SECP256K1(
@@ -292,7 +292,7 @@ fn check_pubkey_conversion_to_sdk() -> anyhow::Result<()> {
         .next()
         .unwrap()
         .clone();
-    x.public_key.to_near_crypto()?;
+    x.public_key.to_near_public_key()?;
     Ok(())
 }
 

--- a/node/src/providers/ecdsa/presign.rs
+++ b/node/src/providers/ecdsa/presign.rs
@@ -74,7 +74,7 @@ impl EcdsaSignatureProvider {
         triple_store: Arc<TripleStorage>,
         domain_id: DomainId,
         presignature_store: Arc<PresignatureStorage>,
-        keygen_out: KeygenOutput<Secp256k1>,
+        keygen_out: KeygenOutput,
     ) -> anyhow::Result<()> {
         let in_flight_generations = InFlightGenerationTracker::new();
         let progress_tracker = Arc::new(PresignatureGenerationProgressTracker {
@@ -200,7 +200,7 @@ pub struct PresignComputation {
     threshold: usize,
     triple0: TripleGenerationOutput<Secp256k1>,
     triple1: TripleGenerationOutput<Secp256k1>,
-    keygen_out: KeygenOutput<Secp256k1>,
+    keygen_out: KeygenOutput,
 }
 
 #[async_trait::async_trait]
@@ -244,7 +244,7 @@ impl MpcLeaderCentricComputation<PresignOutput<Secp256k1>> for PresignComputatio
 pub struct FollowerPresignComputation {
     pub threshold: usize,
     pub paired_triple_id: UniqueId,
-    pub keygen_out: KeygenOutput<Secp256k1>,
+    pub keygen_out: KeygenOutput,
     pub triple_store: Arc<TripleStorage>,
 
     pub out_presignature_store: Arc<PresignatureStorage>,

--- a/node/src/providers/eddsa/kdf.rs
+++ b/node/src/providers/eddsa/kdf.rs
@@ -1,0 +1,17 @@
+//! Key Derivation Function for eddsa keys.
+use cait_sith::eddsa::KeygenOutput;
+use cait_sith::frost_ed25519::keys::SigningShare;
+use cait_sith::frost_ed25519::{Ed25519Group, Group, VerifyingKey};
+use curve25519_dalek::Scalar;
+
+pub(crate) fn derive_keygen_output(keygen_output: &KeygenOutput, tweak: [u8; 32]) -> KeygenOutput {
+    let tweak = Scalar::from_bytes_mod_order(tweak);
+    let private_share = SigningShare::new(keygen_output.private_share.to_scalar() + tweak);
+    let public_key = VerifyingKey::new(
+        keygen_output.public_key.to_element() + Ed25519Group::generator() * tweak,
+    );
+    KeygenOutput {
+        private_share,
+        public_key,
+    }
+}

--- a/node/src/providers/eddsa/mod.rs
+++ b/node/src/providers/eddsa/mod.rs
@@ -123,7 +123,7 @@ impl SignatureProvider for EddsaSignatureProvider {
 }
 
 impl PublicKeyConversion for VerifyingKey {
-    fn to_near_crypto(&self) -> anyhow::Result<near_crypto::PublicKey> {
+    fn to_near_public_key(&self) -> anyhow::Result<near_crypto::PublicKey> {
         let data = self.serialize()?;
         let data: [u8; 32] = data
             .try_into()
@@ -152,7 +152,7 @@ fn check_pubkey_conversion_to_sdk() -> anyhow::Result<()> {
         .next()
         .unwrap()
         .clone();
-    x.public_key.to_near_crypto()?;
+    x.public_key.to_near_public_key()?;
     Ok(())
 }
 

--- a/node/src/providers/eddsa/mod.rs
+++ b/node/src/providers/eddsa/mod.rs
@@ -1,3 +1,4 @@
+mod kdf;
 mod key_generation;
 mod key_resharing;
 mod sign;
@@ -5,16 +6,15 @@ mod sign;
 use crate::config::{ConfigFile, MpcConfig, ParticipantsConfig};
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::MpcTaskId;
-use crate::providers::SignatureProvider;
+use crate::providers::{PublicKeyConversion, SignatureProvider};
 use crate::sign_request::{SignRequestStorage, SignatureId};
 use borsh::{BorshDeserialize, BorshSerialize};
 use cait_sith::eddsa::KeygenOutput;
-use frost_ed25519::keys::{PublicKeyPackage, SigningShare};
-use frost_ed25519::{Signature, VerifyingKey};
+use cait_sith::frost_ed25519::keys::SigningShare;
+use cait_sith::frost_ed25519::{Signature, VerifyingKey};
 use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::key_state::KeyEventId;
-use std::collections::{BTreeMap, HashMap};
-use std::str::FromStr;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -58,16 +58,16 @@ impl From<EddsaTaskId> for MpcTaskId {
 }
 
 impl SignatureProvider for EddsaSignatureProvider {
-    type PublicKey = PublicKeyPackage;
+    type PublicKey = VerifyingKey;
     type SecretShare = SigningShare;
     type KeygenOutput = KeygenOutput;
-    type SignatureOutput = (Signature, VerifyingKey);
+    type Signature = Signature;
     type TaskId = EddsaTaskId;
 
     async fn make_signature(
         self: Arc<Self>,
         id: SignatureId,
-    ) -> anyhow::Result<Self::SignatureOutput> {
+    ) -> anyhow::Result<(Self::Signature, Self::PublicKey)> {
         self.make_signature_leader(id).await
     }
 
@@ -81,7 +81,7 @@ impl SignatureProvider for EddsaSignatureProvider {
     async fn run_key_resharing_client(
         new_threshold: usize,
         key_share: Option<SigningShare>,
-        public_key: PublicKeyPackage,
+        public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
@@ -122,33 +122,25 @@ impl SignatureProvider for EddsaSignatureProvider {
     }
 }
 
-pub fn convert_to_near_pubkey(
-    public_key_package: &PublicKeyPackage,
-) -> anyhow::Result<near_crypto::PublicKey> {
-    let data = public_key_package.verifying_key().serialize()?;
-    let data: [u8; 32] = data
-        .try_into()
-        .or_else(|_| anyhow::bail!("Serialized public key is not 32 bytes."))?;
-    Ok(near_crypto::PublicKey::ED25519(
-        near_crypto::ED25519PublicKey::from(data),
-    ))
-}
-
-pub fn convert_from_near_pubkey(key: near_crypto::PublicKey) -> anyhow::Result<PublicKeyPackage> {
-    match key {
-        near_crypto::PublicKey::ED25519(key) => {
-            let verifying_key = VerifyingKey::deserialize(key.0.as_slice())?;
-            Ok(PublicKeyPackage::new(BTreeMap::new(), verifying_key))
-        }
-        _ => anyhow::bail!("Unsupported public key type"),
+impl PublicKeyConversion for VerifyingKey {
+    fn to_near_crypto(&self) -> anyhow::Result<near_crypto::PublicKey> {
+        let data = self.serialize()?;
+        let data: [u8; 32] = data
+            .try_into()
+            .or_else(|_| anyhow::bail!("Serialized public key is not 32 bytes."))?;
+        Ok(near_crypto::PublicKey::ED25519(
+            near_crypto::ED25519PublicKey::from(data),
+        ))
     }
-}
 
-pub fn convert_from_sdk_pubkey(
-    public_key: &near_sdk::PublicKey,
-) -> anyhow::Result<PublicKeyPackage> {
-    let near_crypto = near_crypto::PublicKey::from_str(&String::from(public_key))?;
-    convert_from_near_pubkey(near_crypto)
+    fn from_near_crypto(public_key: &near_crypto::PublicKey) -> anyhow::Result<Self> {
+        match public_key {
+            near_crypto::PublicKey::ED25519(key) => {
+                Ok(VerifyingKey::deserialize(key.0.as_slice())?)
+            }
+            _ => anyhow::bail!("Unsupported public key type"),
+        }
+    }
 }
 
 #[test]
@@ -160,14 +152,15 @@ fn check_pubkey_conversion_to_sdk() -> anyhow::Result<()> {
         .next()
         .unwrap()
         .clone();
-    convert_to_near_pubkey(&x.public_key_package)?;
+    x.public_key.to_near_crypto()?;
     Ok(())
 }
 
 #[test]
 fn check_pubkey_conversion_from_sdk() -> anyhow::Result<()> {
+    use std::str::FromStr;
     let near_sdk =
         near_sdk::PublicKey::from_str("ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp")?;
-    let _ = convert_from_sdk_pubkey(&near_sdk)?;
+    let _ = VerifyingKey::from_near_sdk(&near_sdk)?;
     Ok(())
 }

--- a/node/src/providers/mod.rs
+++ b/node/src/providers/mod.rs
@@ -79,7 +79,7 @@ pub trait HasParticipants {
 
 /// Helper functions to convert back and forth public key types
 pub trait PublicKeyConversion: Sized {
-    fn to_near_crypto(&self) -> anyhow::Result<near_crypto::PublicKey>;
+    fn to_near_public_key(&self) -> anyhow::Result<near_crypto::PublicKey>;
     fn from_near_crypto(public_key: &near_crypto::PublicKey) -> anyhow::Result<Self>;
 
     // Don't implement it

--- a/node/src/providers/mod.rs
+++ b/node/src/providers/mod.rs
@@ -15,15 +15,16 @@ use crate::primitives::{MpcTaskId, ParticipantId};
 use crate::sign_request::SignatureId;
 pub use ecdsa::EcdsaSignatureProvider;
 pub use ecdsa::EcdsaTaskId;
+use std::str::FromStr;
 use std::sync::Arc;
 
 /// The interface that defines the requirements for a signing schema to be correctly used in the code.
 pub trait SignatureProvider {
-    type PublicKey;
+    type PublicKey: PublicKeyConversion;
     type SecretShare;
     type KeygenOutput;
 
-    type SignatureOutput;
+    type Signature;
 
     /// Trait bound `Into<MpcTaskId>` serves as a way to see what logic needs to be added,
     /// when introducing new `TaskId`. Implementation of the trait should be trivial.
@@ -35,7 +36,7 @@ pub trait SignatureProvider {
     async fn make_signature(
         self: Arc<Self>,
         id: SignatureId,
-    ) -> anyhow::Result<Self::SignatureOutput>;
+    ) -> anyhow::Result<(Self::Signature, Self::PublicKey)>;
 
     /// Executes the key generation protocol.
     /// Returns once key generation is complete or encounters an error.
@@ -74,4 +75,16 @@ pub trait SignatureProvider {
 /// This trait helps check whether the current set of participants contains `A`.
 pub trait HasParticipants {
     fn is_subset_of_active_participants(&self, active_participants: &[ParticipantId]) -> bool;
+}
+
+/// Helper functions to convert back and forth public key types
+pub trait PublicKeyConversion: Sized {
+    fn to_near_crypto(&self) -> anyhow::Result<near_crypto::PublicKey>;
+    fn from_near_crypto(public_key: &near_crypto::PublicKey) -> anyhow::Result<Self>;
+
+    // Don't implement it
+    fn from_near_sdk(public_key: &near_sdk::PublicKey) -> anyhow::Result<Self> {
+        let near_crypto = near_crypto::PublicKey::from_str(&String::from(public_key))?;
+        Self::from_near_crypto(&near_crypto)
+    }
 }

--- a/node/src/tests/benchmark.rs
+++ b/node/src/tests/benchmark.rs
@@ -34,7 +34,14 @@ fn benchmark_single_threaded_signature_generation() {
     for _ in 0..COUNT {
         let _ = generator.make_signature(
             &presignatures,
-            keygens.iter().next().unwrap().1.public_key,
+            keygens
+                .iter()
+                .next()
+                .unwrap()
+                .1
+                .public_key
+                .to_element()
+                .to_affine(),
             Scalar::random(&mut rand::thread_rng()),
         );
     }

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -70,8 +70,8 @@ impl TestGenerators {
         self.participants.iter().map(|p| (*p).into()).collect()
     }
 
-    pub fn make_ecdsa_keygens(&self) -> HashMap<Participant, ecdsa::KeygenOutput<Secp256k1>> {
-        let mut protocols: Vec<ParticipantAndProtocol<ecdsa::KeygenOutput<Secp256k1>>> = Vec::new();
+    pub fn make_ecdsa_keygens(&self) -> HashMap<Participant, ecdsa::KeygenOutput> {
+        let mut protocols: Vec<ParticipantAndProtocol<ecdsa::KeygenOutput>> = Vec::new();
         for participant in &self.participants {
             protocols.push((
                 *participant,
@@ -121,7 +121,7 @@ impl TestGenerators {
         &self,
         triple0s: &HashMap<Participant, TripleGenerationOutput<Secp256k1>>,
         triple1s: &HashMap<Participant, TripleGenerationOutput<Secp256k1>>,
-        keygens: &HashMap<Participant, ecdsa::KeygenOutput<Secp256k1>>,
+        keygens: &HashMap<Participant, ecdsa::KeygenOutput>,
     ) -> HashMap<Participant, PresignOutput<Secp256k1>> {
         let mut protocols: Vec<ParticipantAndProtocol<PresignOutput<Secp256k1>>> = Vec::new();
         for participant in &self.participants {

--- a/node/src/tests/research.rs
+++ b/node/src/tests/research.rs
@@ -300,7 +300,10 @@ fn signature_network_research_best_case() {
             cait_sith::ecdsa::sign::sign(
                 &participants,
                 participants[i],
-                keygens[&participants[i]].public_key,
+                keygens[&participants[i]]
+                    .public_key
+                    .to_element()
+                    .to_affine(),
                 presignatures[&participants[i]].clone(),
                 Scalar::from_u128(100000),
             )


### PR DESCRIPTION
This PR is a follow-up after https://github.com/Near-One/cait-sith/pull/19
Changes include:
* Move from cait-sith style keygen struct to frost style
* Refactoring around eddsa signature
* Refactoring around Public key conversion into/from near sdk