### PR TITLE
Devnet: option to use own funding account

### DIFF
--- a/devnet/README.md
+++ b/devnet/README.md
@@ -19,6 +19,16 @@ edit it:
     available throughput.
 * Set the directory of your local clone of the infra-ops repository.
   This is used for Terraform deployment of the test cluster.
+* Set `rpcs` to point to your RPC endpoints
+* (Optional) Configure a `funding_account` to use a specific account for funding operations:
+  ```yaml
+  funding_account:
+    account_id: your-account.testnet
+    access_keys:
+      - ed25519:xxxxxx  # Your private key
+    kind: funding_account
+  ```
+  If not provided, the devnet will create a funding account from the testnet faucet.
 
 ## How the CLI Works
 This CLI is somewhat similar to Terraform in spirit. As soon as you

--- a/devnet/config.yaml.template
+++ b/devnet/config.yaml.template
@@ -2,4 +2,12 @@ rpcs:
   - url: http://replace_me:3030
     rate_limit: 5
     max_concurrency: 30
+
 infra_ops_path: /replace_me/infra-ops
+
+# Optional own funding account
+# funding_account:
+# account_id: your-funding-account.testnet
+# kind: FundingAccount
+# access_keys:
+#   - ed25519:your_private_key_here

--- a/devnet/src/account.rs
+++ b/devnet/src/account.rs
@@ -495,7 +495,12 @@ impl OperatingAccounts {
             .send()
             .await
             .unwrap();
-        assert_eq!(result.status(), StatusCode::OK);
+        if result.status() != StatusCode::OK {
+            let status = result.status();
+            let error_text = result.text().await.unwrap_or_else(|_| "No error message".to_string());
+            println!("Faucet RPC request failed: status {}, {}", status, error_text);
+            std::process::exit(1);
+        }
         let new_account = NearAccount {
             account_id: new_account_id.clone(),
             access_keys: vec![secret_key],

--- a/devnet/src/account.rs
+++ b/devnet/src/account.rs
@@ -410,9 +410,12 @@ impl OperatingAccount {
 
 /// Represents the live state of the collection of all accounts the CLI knows.
 pub struct OperatingAccounts {
-    accounts: HashMap<AccountId, OperatingAccount>,
-    recent_block_hash: CryptoHash,
-    client: Arc<NearRpcClients>,
+    /// The current view of the account data. This is persisted at the end of the CLI run.
+    pub accounts: HashMap<AccountId, OperatingAccount>,
+    /// A recent block hash for submitting transactions to chain.
+    pub recent_block_hash: CryptoHash,
+    /// RPC for submitting transactions.
+    pub client: Arc<NearRpcClients>,
 }
 
 impl OperatingAccounts {

--- a/devnet/src/account.rs
+++ b/devnet/src/account.rs
@@ -497,8 +497,14 @@ impl OperatingAccounts {
             .unwrap();
         if result.status() != StatusCode::OK {
             let status = result.status();
-            let error_text = result.text().await.unwrap_or_else(|_| "No error message".to_string());
-            println!("Faucet RPC request failed: status {}, {}", status, error_text);
+            let error_text = result
+                .text()
+                .await
+                .unwrap_or_else(|_| "No error message".to_string());
+            println!(
+                "Faucet RPC request failed: status {}, {}",
+                status, error_text
+            );
             std::process::exit(1);
         }
         let new_account = NearAccount {

--- a/devnet/src/funding.rs
+++ b/devnet/src/funding.rs
@@ -121,7 +121,9 @@ pub async fn fund_accounts(
                         ),
                     );
                 }
-                let balance = accounts.get_account_balance(&funding_account.account_id).await;
+                let balance = accounts
+                    .get_account_balance(&funding_account.account_id)
+                    .await;
                 funding_accounts.push_back((
                     funding_account.account_id.clone(),
                     balance.saturating_sub(MINIMUM_BALANCE_TO_REMAIN_IN_ACCOUNTS),

--- a/devnet/src/loadtest.rs
+++ b/devnet/src/loadtest.rs
@@ -77,7 +77,14 @@ impl NewLoadtestCmd {
         loadtest_setup.desired_balance_per_account = self.near_per_account * ONE_NEAR;
         loadtest_setup.desired_keys_per_account = self.keys_per_account;
 
-        update_loadtest_setup(name, &mut setup.accounts, loadtest_setup, self.num_accounts, config.funding_account).await;
+        update_loadtest_setup(
+            name,
+            &mut setup.accounts,
+            loadtest_setup,
+            self.num_accounts,
+            config.funding_account,
+        )
+        .await;
     }
 }
 
@@ -150,11 +157,15 @@ impl DeployParallelSignContractCmd {
             } else {
                 AccountToFund::from_new(self.deposit_near * ONE_NEAR, format!("par-sign-{}-", name))
             };
-        let contract_account = fund_accounts(&mut setup.accounts, vec![contract_account_to_fund], config.funding_account)
-            .await
-            .into_iter()
-            .next()
-            .unwrap();
+        let contract_account = fund_accounts(
+            &mut setup.accounts,
+            vec![contract_account_to_fund],
+            config.funding_account,
+        )
+        .await
+        .into_iter()
+        .next()
+        .unwrap();
         loadtest_setup.parallel_signatures_contract = Some(contract_account.clone());
 
         setup

--- a/devnet/src/mpc.rs
+++ b/devnet/src/mpc.rs
@@ -7,7 +7,7 @@ use crate::cli::{
 use crate::constants::ONE_NEAR;
 use crate::devnet::OperatingDevnetSetup;
 use crate::funding::{fund_accounts, AccountToFund};
-use crate::types::{MpcNetworkSetup, MpcParticipantSetup, ParsedConfig};
+use crate::types::{MpcNetworkSetup, MpcParticipantSetup, ParsedConfig, NearAccount};
 use legacy_mpc_contract::config::InitConfigV1;
 use legacy_mpc_contract::primitives::{self, CandidateInfo, SignRequest};
 use near_crypto::SecretKey;
@@ -22,6 +22,7 @@ async fn update_mpc_network(
     accounts: &mut OperatingAccounts,
     mpc_setup: &mut MpcNetworkSetup,
     desired_num_participants: usize,
+    funding_account: Option<NearAccount>,
 ) {
     if desired_num_participants < mpc_setup.participants.len() {
         panic!(
@@ -60,7 +61,7 @@ async fn update_mpc_network(
             ));
         }
     }
-    let funded_accounts = fund_accounts(accounts, accounts_to_fund).await;
+    let funded_accounts = fund_accounts(accounts, accounts_to_fund, funding_account).await;
 
     for i in mpc_setup.participants.len()..desired_num_participants {
         let account_id = funded_accounts[i * 2].clone();
@@ -121,7 +122,7 @@ impl NewMpcNetworkCmd {
                 desired_balance_per_responding_account: self.near_per_responding_account * ONE_NEAR,
                 nomad_server_url: None,
             });
-        update_mpc_network(name, &mut setup.accounts, mpc_setup, self.num_participants).await;
+        update_mpc_network(name, &mut setup.accounts, mpc_setup, self.num_participants, config.funding_account).await;
     }
 }
 
@@ -156,7 +157,7 @@ impl UpdateMpcNetworkCmd {
                 near_per_responding_account * ONE_NEAR;
         }
 
-        update_mpc_network(name, &mut setup.accounts, mpc_setup, num_participants).await;
+        update_mpc_network(name, &mut setup.accounts, mpc_setup, num_participants, config.funding_account).await;
     }
 }
 
@@ -195,7 +196,7 @@ impl MpcDeployContractCmd {
                 format!("mpc-contract-{}-", name),
             )
         };
-        let contract_account = fund_accounts(&mut setup.accounts, vec![contract_account_to_fund])
+        let contract_account = fund_accounts(&mut setup.accounts, vec![contract_account_to_fund], config.funding_account)
             .await
             .into_iter()
             .next()

--- a/devnet/src/mpc.rs
+++ b/devnet/src/mpc.rs
@@ -7,7 +7,7 @@ use crate::cli::{
 use crate::constants::ONE_NEAR;
 use crate::devnet::OperatingDevnetSetup;
 use crate::funding::{fund_accounts, AccountToFund};
-use crate::types::{MpcNetworkSetup, MpcParticipantSetup, ParsedConfig, NearAccount};
+use crate::types::{MpcNetworkSetup, MpcParticipantSetup, NearAccount, ParsedConfig};
 use legacy_mpc_contract::config::InitConfigV1;
 use legacy_mpc_contract::primitives::{self, CandidateInfo, SignRequest};
 use near_crypto::SecretKey;
@@ -122,7 +122,14 @@ impl NewMpcNetworkCmd {
                 desired_balance_per_responding_account: self.near_per_responding_account * ONE_NEAR,
                 nomad_server_url: None,
             });
-        update_mpc_network(name, &mut setup.accounts, mpc_setup, self.num_participants, config.funding_account).await;
+        update_mpc_network(
+            name,
+            &mut setup.accounts,
+            mpc_setup,
+            self.num_participants,
+            config.funding_account,
+        )
+        .await;
     }
 }
 
@@ -157,7 +164,14 @@ impl UpdateMpcNetworkCmd {
                 near_per_responding_account * ONE_NEAR;
         }
 
-        update_mpc_network(name, &mut setup.accounts, mpc_setup, num_participants, config.funding_account).await;
+        update_mpc_network(
+            name,
+            &mut setup.accounts,
+            mpc_setup,
+            num_participants,
+            config.funding_account,
+        )
+        .await;
     }
 }
 
@@ -196,11 +210,15 @@ impl MpcDeployContractCmd {
                 format!("mpc-contract-{}-", name),
             )
         };
-        let contract_account = fund_accounts(&mut setup.accounts, vec![contract_account_to_fund], config.funding_account)
-            .await
-            .into_iter()
-            .next()
-            .unwrap();
+        let contract_account = fund_accounts(
+            &mut setup.accounts,
+            vec![contract_account_to_fund],
+            config.funding_account,
+        )
+        .await
+        .into_iter()
+        .next()
+        .unwrap();
         mpc_setup.contract = Some(contract_account.clone());
 
         setup

--- a/devnet/src/types.rs
+++ b/devnet/src/types.rs
@@ -73,6 +73,7 @@ pub struct LoadtestSetup {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
     pub rpcs: Vec<RpcConfig>,
+    pub funding_account: Option<NearAccount>,
     // Path of the Near-One/infra-ops repository.
     // Used only for terraform deployment commands.
     pub infra_ops_path: String,
@@ -90,6 +91,7 @@ pub struct RpcConfig {
 pub struct ParsedConfig {
     pub rpc: Arc<NearRpcClients>,
     pub infra_ops_path: PathBuf,
+    pub funding_account: Option<NearAccount>,
 }
 
 pub async fn load_config() -> ParsedConfig {
@@ -100,5 +102,6 @@ pub async fn load_config() -> ParsedConfig {
     ParsedConfig {
         rpc: client,
         infra_ops_path: PathBuf::from(config.infra_ops_path),
+        funding_account: config.funding_account,
     }
 }


### PR DESCRIPTION
This is to overcome testnet faucet not being available.
Tested and deployed a new cluster

```
➜  devnet git:(main) ✗ RUST_BACKTRACE=1 cargo run mpc and-upg new \
  --num-participants 2 \
  --threshold 1 \
  --num-responding-access-keys 1 \
  --near-per-responding-account 1
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/devnet mpc and-upg new --num-participants 2 --threshold 1 --num-responding-access-keys 1 --near-per-responding-account 1`
Going to create MPC network and-upg with 2 participants, threshold 1, 1 NEAR per account, and 1 additional access keys per participant for responding
Using provided funding account andrei-devnet.testnet from config
[andrei-devnet.testnet] Creating account mpc-0-and-upg-26b2094f1da5.andrei-devnet.testnet with 1000000000000000000000000 NEAR
[andrei-devnet.testnet] Creating account mpc-responder-0-and-upg-2a0b4e19aaf3.andrei-devnet.testnet with 1000000000000000000000000 NEAR
[andrei-devnet.testnet] Creating account mpc-1-and-upg-5a31c3d4ec91.andrei-devnet.testnet with 1000000000000000000000000 NEAR
[andrei-devnet.testnet] Creating account mpc-responder-1-and-upg-e1a4b788f22c.andrei-devnet.testnet with 1000000000000000000000000 NEAR
Account mpc-responder-1-and-upg-e1a4b788f22c.andrei-devnet.testnet now has 1 keys
Account mpc-responder-0-and-upg-2a0b4e19aaf3.andrei-devnet.testnet now has 1 keys
```