### PR TITLE
tempfile 3.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,12 +3610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
-
-[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7027,19 +7021,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
-dependencies = [
- "bitflags 2.9.0",
- "errno 0.3.10",
- "libc",
- "linux-raw-sys 0.9.3",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7894,14 +7875,14 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
+ "cfg-if 1.0.0",
  "fastrand 2.3.0",
- "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
 serde_yaml = "0.9.34"
 sha3 = "0.10.8"
-tempfile = "3.14.0"
+tempfile = "=3.14.0"
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-util = "0.7.12"
 tokio-rustls = { version = "0.26.1", default-features = false }


### PR DESCRIPTION
This is to fix the tempfile != 3.14 [issue]([#nearone/private > 2.5.0 Invalid cross-device link issue](https://near.zulipchat.com/#narrow/channel/308695-nearone.2Fprivate/topic/2.2E5.2E0.20Invalid.20cross-device.20link.20issue/with/504454634))
#15 39.15  [ Downloaded tempfile v3.14.0](https://github.com/Near-One/mpc/actions/runs/14273343466/job/40011339924)