### PR TITLE
Revert resharing on testnet

### DIFF
--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -760,7 +760,7 @@ impl VersionedMpcContract {
 
     // This function can be used to transfer the MPC network to a new contract.
     #[private]
-    #[init]
+    #[init(ignore_state)]
     #[handle_result]
     pub fn init_running(
         epoch: u64,

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -822,7 +822,34 @@ impl VersionedMpcContract {
                     proposed_updates: ProposedUpdates::default(),
                 }))
             }
-            VersionedMpcContract::V1(_) => Ok(old),
+            VersionedMpcContract::V1(old) => {
+                let ProtocolContractState::Resharing(ResharingContractState {
+                    old_epoch,
+                    old_participants,
+                    threshold,
+                    public_key,
+                    ..
+                }) = old.protocol_state
+                else {
+                    env::panic_str("expected resharing state");
+                };
+                let protocol_state = state::ProtocolContractState::Running(RunningContractState {
+                    epoch: old_epoch,
+                    participants: old_participants,
+                    threshold,
+                    public_key,
+                    candidates: Candidates::new(),
+                    join_votes: Votes::new(),
+                    leave_votes: Votes::new(),
+                });
+                Ok(VersionedMpcContract::V1(MpcContractV1 {
+                    protocol_state,
+                    pending_requests: old.pending_requests,
+                    request_by_block_height: old.request_by_block_height,
+                    proposed_updates: old.proposed_updates,
+                    config: old.config,
+                }))
+            }
         }
     }
 


### PR DESCRIPTION
This contract update (for V1.0.1) will exit resharing state and resume the previous running state. Node operators can then kick out the unresponsive node.

The contract version stays the same, because the contract logic and state structure remain the same. Only the migration function changes.