### PR TITLE
refactor: Remove `ScalarExt` trait

### DIFF
--- a/libs/chain-signatures/contract/src/crypto_shared/mod.rs
+++ b/libs/chain-signatures/contract/src/crypto_shared/mod.rs
@@ -6,7 +6,7 @@ pub use kdf::{derive_key_secp256k1, derive_tweak, x_coordinate};
 pub use types::{
     edd25519_types,
     k256_types::{self, SerializableAffinePoint, SerializableScalar},
-    ScalarExt, SignatureResponse,
+    SignatureResponse,
 };
 
 // Our wasm runtime doesn't support good syncronous entropy.

--- a/libs/chain-signatures/contract/src/crypto_shared/types.rs
+++ b/libs/chain-signatures/contract/src/crypto_shared/types.rs
@@ -3,8 +3,8 @@ use std::fmt::Display;
 use borsh::{BorshDeserialize, BorshSerialize};
 use curve25519_dalek::EdwardsPoint;
 use k256::{
-    elliptic_curve::{bigint::ArrayEncoding, group::GroupEncoding, CurveArithmetic, PrimeField},
-    AffinePoint, Secp256k1, U256,
+    elliptic_curve::{group::GroupEncoding, CurveArithmetic, PrimeField},
+    AffinePoint, Secp256k1,
 };
 use near_sdk::near;
 use serde::{Deserialize, Serialize};
@@ -180,39 +180,11 @@ mod serialize {
     }
 }
 
-pub trait ScalarExt: Sized {
-    fn from_bytes(bytes: [u8; 32]) -> Option<Self>;
-    fn from_non_biased(bytes: [u8; 32]) -> Self;
-    fn to_bytes(&self) -> [u8; 32];
-}
-
 pub mod k256_types {
     use super::*;
     use k256::Scalar;
 
     pub type PublicKey = <Secp256k1 as CurveArithmetic>::AffinePoint;
-
-    impl ScalarExt for Scalar {
-        /// Returns nothing if the bytes are greater than the field size of Secp256k1.
-        /// This will be very rare with random bytes as the field size is 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
-        fn from_bytes(bytes: [u8; 32]) -> Option<Self> {
-            let bytes = U256::from_be_slice(bytes.as_slice());
-            Self::from_repr(bytes.to_be_byte_array()).into_option()
-        }
-
-        /// When the user can't directly select the value, this will always work
-        /// Use cases are things that we know have been hashed
-        fn from_non_biased(hash: [u8; 32]) -> Self {
-            // This should never happen.
-            // The space of inputs is 2^256, the space of the field is ~2^256 - 2^129.
-            // This mean that you'd have to run 2^127 hashes to find a value that causes this to fail.
-            Self::from_bytes(hash).expect("Derived scalar value falls outside of the field")
-        }
-
-        fn to_bytes(&self) -> [u8; 32] {
-            self.to_bytes().into()
-        }
-    }
 
     // Is there a better way to force a borsh serialization?
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy, Ord, PartialOrd)]
@@ -242,10 +214,13 @@ pub mod k256_types {
     impl BorshDeserialize for SerializableScalar {
         fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
             let from_ser: [u8; 32] = BorshDeserialize::deserialize_reader(reader)?;
-            let scalar = Scalar::from_bytes(from_ser).ok_or(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "The given scalar is not in the field of Secp256k1",
-            ))?;
+            let scalar =
+                Scalar::from_repr(from_ser.into())
+                    .into_option()
+                    .ok_or(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "The given scalar is not in the field of Secp256k1",
+                    ))?;
             Ok(SerializableScalar { scalar })
         }
     }
@@ -295,26 +270,6 @@ pub mod edd25519_types {
     use super::*;
     use curve25519_dalek::Scalar;
 
-    impl ScalarExt for Scalar {
-        fn from_bytes(bytes: [u8; 32]) -> Option<Self> {
-            Self::from_repr(bytes).into_option()
-        }
-
-        /// When the user can't directly select the value, this will always work
-        /// Use cases are things that we know have been hashed
-        fn from_non_biased(hash: [u8; 32]) -> Self {
-            // This should never happen.
-            // The space of inputs is 2^256, the space of the field is ~2^256 - 2^129.
-            // This mean that you'd have to run 2^127 hashes to find a value that causes this to fail.
-            Self::from_bytes(hash)
-                .expect("Derived scalar value falls outside of the field of edd25519")
-        }
-
-        fn to_bytes(&self) -> [u8; 32] {
-            self.to_bytes()
-        }
-    }
-
     // Is there a better way to force a borsh serialization?
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
     pub struct SerializableScalar {
@@ -343,10 +298,12 @@ pub mod edd25519_types {
     impl BorshDeserialize for SerializableScalar {
         fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
             let from_ser: [u8; 32] = BorshDeserialize::deserialize_reader(reader)?;
-            let scalar = Scalar::from_bytes(from_ser).ok_or(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "The given scalar is not in the field of edd25519",
-            ))?;
+            let scalar = Scalar::from_repr(from_ser)
+                .into_option()
+                .ok_or(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "The given scalar is not in the field of edd25519",
+                ))?;
             Ok(SerializableScalar { scalar })
         }
     }
@@ -387,7 +344,7 @@ mod test {
             k256::Scalar::ZERO,
             k256::Scalar::ONE,
             k256::Scalar::from_u128(u128::MAX),
-            k256::Scalar::from_bytes([3; 32]).unwrap(),
+            k256::Scalar::from_repr([3; 32].into()).unwrap(),
         ];
 
         for scalar in test_vec.into_iter() {

--- a/libs/chain-signatures/contract/src/errors/impls.rs
+++ b/libs/chain-signatures/contract/src/errors/impls.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
 use std::fmt;
 
+use crate::crypto_shared::kdf::TweakNotOnCurve;
+
 use super::{
     ConversionError, DomainError, Error, ErrorKind, ErrorRepr, InvalidCandidateSet,
     InvalidParameters, InvalidState, InvalidThreshold, KeyEventError, PublicKeyError, RespondError,
@@ -148,5 +150,17 @@ impl From<InvalidCandidateSet> for Error {
 impl From<DomainError> for Error {
     fn from(code: DomainError) -> Self {
         Self::simple(ErrorKind::DomainError(code))
+    }
+}
+
+impl From<TweakNotOnCurve> for PublicKeyError {
+    fn from(_: TweakNotOnCurve) -> Self {
+        Self::TweakNotOnCurve
+    }
+}
+
+impl From<TweakNotOnCurve> for RespondError {
+    fn from(_: TweakNotOnCurve) -> Self {
+        Self::TweakNotOnCurve
     }
 }

--- a/libs/chain-signatures/contract/src/errors/mod.rs
+++ b/libs/chain-signatures/contract/src/errors/mod.rs
@@ -21,6 +21,8 @@ pub enum RespondError {
     SignatureSchemeMismatch,
     #[error("The provided domain was not found.")]
     DomainNotFound,
+    #[error("The provided tweak is not on the curve of the public key.")]
+    TweakNotOnCurve,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]
@@ -29,6 +31,8 @@ pub enum PublicKeyError {
     DerivedKeyConversionFailed,
     #[error("The provided domain was not found.")]
     DomainNotFound,
+    #[error("The provided tweak is not on the curve of the public key.")]
+    TweakNotOnCurve,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -16,13 +16,13 @@ use crypto_shared::{
     kdf::{check_ec_signature, derive_public_key_edwards_point_edd25519},
     near_public_key_to_affine_point,
     types::SignatureResponse,
-    ScalarExt as _,
 };
 use errors::{
     ConversionError, DomainError, InvalidParameters, InvalidState, PublicKeyError, RespondError,
     SignError,
 };
 use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::elliptic_curve::PrimeField;
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
     env::{self, ed25519_verify},
@@ -217,8 +217,9 @@ impl VersionedMpcContract {
         // This allows users to get the error message
         match &curve_type {
             CurveType::SECP256K1 => {
-                let hash = request.payload.as_ecdsa().expect("Payload is not Ecdsa");
-                k256::Scalar::from_bytes(*hash)
+                let hash = *request.payload.as_ecdsa().expect("Payload is not Ecdsa");
+                k256::Scalar::from_repr(hash.into())
+                    .into_option()
                     .expect("Ecdsa payload cannot be converted to Scalar");
             }
             CurveType::ED25519 => {
@@ -334,14 +335,18 @@ impl VersionedMpcContract {
         let derived_public_key = match public_key {
             PublicKeyExtended::Secp256k1 { near_public_key } => {
                 let derived_public_key =
-                    derive_key_secp256k1(&near_public_key_to_affine_point(near_public_key), &tweak);
+                    derive_key_secp256k1(&near_public_key_to_affine_point(near_public_key), &tweak)
+                        .map_err(PublicKeyError::from)?;
+
                 let encoded_point = derived_public_key.to_encoded_point(false);
                 let slice: &[u8] = &encoded_point.as_bytes()[1..65];
                 PublicKey::from_parts(CurveType::SECP256K1, slice.to_vec())
             }
             PublicKeyExtended::Ed25519 { edwards_point, .. } => {
                 let derived_public_key_edwards_point =
-                    derive_public_key_edwards_point_edd25519(&edwards_point, &tweak);
+                    derive_public_key_edwards_point_edd25519(&edwards_point, &tweak)
+                        .map_err(PublicKeyError::from)?;
+
                 let encoded_point: [u8; 32] =
                     derived_public_key_edwards_point.compress().to_bytes();
 
@@ -391,7 +396,8 @@ impl VersionedMpcContract {
                 let expected_public_key = derive_key_secp256k1(
                     &near_public_key_to_affine_point(near_public_key),
                     &request.tweak,
-                );
+                )
+                .map_err(RespondError::from)?;
 
                 let payload_hash = request.payload.as_ecdsa().expect("Payload is not ECDSA");
 
@@ -415,7 +421,8 @@ impl VersionedMpcContract {
                 let derived_public_key_edwards_point = derive_public_key_edwards_point_edd25519(
                     &public_key_edwards_point,
                     &request.tweak,
-                );
+                )
+                .map_err(RespondError::from)?;
 
                 let derived_public_key_32_bytes =
                     *derived_public_key_edwards_point.compress().as_bytes();
@@ -866,7 +873,7 @@ mod tests {
     use rand::RngCore;
 
     pub fn derive_secret_key(secret_key: &k256::SecretKey, tweak: &Tweak) -> k256::SecretKey {
-        let tweak = k256::Scalar::from_non_biased(tweak.as_bytes());
+        let tweak = k256::Scalar::from_repr(tweak.as_bytes().into()).unwrap();
         k256::SecretKey::new((tweak + secret_key.to_nonzero_scalar().as_ref()).into())
     }
 
@@ -946,14 +953,14 @@ mod tests {
         let signature_response = if success {
             SignatureResponse::Secp256k1(k256_types::SignatureResponse::new(
                 AffinePoint::decompact(&r).unwrap(),
-                k256::Scalar::from_bytes(bytes).unwrap(),
+                k256::Scalar::from_repr(bytes.into()).unwrap(),
                 recovery_id.to_byte(),
             ))
         } else {
             // submit an incorrect signature to make the respond call fail
             SignatureResponse::Secp256k1(k256_types::SignatureResponse::new(
                 AffinePoint::decompact(&r).unwrap(),
-                k256::Scalar::from_bytes([0u8; 32]).unwrap(),
+                k256::Scalar::from_repr([0u8; 32].into()).unwrap(),
                 recovery_id.to_byte(),
             ))
         };

--- a/node/src/providers/ecdsa/kdf.rs
+++ b/node/src/providers/ecdsa/kdf.rs
@@ -2,8 +2,8 @@ use crate::primitives::ParticipantId;
 use hex_literal::hex;
 use hkdf::Hkdf;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::elliptic_curve::PrimeField;
 use k256::{AffinePoint, Scalar};
-use mpc_contract::crypto_shared::ScalarExt;
 use sha3::Sha3_256;
 
 /// The following salt is picked by hashing with sha256
@@ -58,7 +58,7 @@ pub fn derive_randomness(
         hk.expand(&concatenation, &mut okm).unwrap();
 
         // derive the randomness delta
-        delta = Scalar::from_bytes(okm).unwrap_or(
+        delta = Scalar::from_repr(okm.into()).unwrap_or(
             // if delta falls outside the field
             // probability is negligible: in the order of 1/2^224
             Scalar::ZERO,

--- a/node/src/providers/ecdsa/sign.rs
+++ b/node/src/providers/ecdsa/sign.rs
@@ -13,8 +13,8 @@ use cait_sith::ecdsa::presign::PresignOutput;
 use cait_sith::ecdsa::sign::FullSignature;
 use cait_sith::frost_secp256k1::VerifyingKey;
 use cait_sith::protocol::Participant;
+use k256::elliptic_curve::PrimeField;
 use k256::{Scalar, Secp256k1};
-use mpc_contract::crypto_shared::ScalarExt;
 use mpc_contract::primitives::signature::Tweak;
 use std::sync::Arc;
 use std::time::Duration;
@@ -118,10 +118,12 @@ impl MpcLeaderCentricComputation<(FullSignature<Secp256k1>, VerifyingKey)> for S
             .collect::<Vec<_>>();
         let me = channel.my_participant_id();
 
-        let tweak =
-            Scalar::from_bytes(self.tweak.as_bytes()).context("Couldn't construct k256 point")?;
-        let msg_hash =
-            Scalar::from_bytes(self.msg_hash).context("Couldn't construct k256 point")?;
+        let tweak = Scalar::from_repr(self.tweak.as_bytes().into())
+            .into_option()
+            .context("Couldn't construct k256 point")?;
+        let msg_hash = Scalar::from_repr(self.msg_hash.into())
+            .into_option()
+            .context("Couldn't construct k256 point")?;
 
         let public_key =
             derive_public_key(self.keygen_out.public_key.to_element().to_affine(), tweak);


### PR DESCRIPTION
This PR removes the `ScalarExt` trait found in `libs/chain-signatures/contract/src/crypto_shared/types.rs`.

The trait was just a collection of wrapper functions around `k256::Scalar::from_repr` and `curve_25519::Scalar::from_repr`, with an added unwrap to it. This made it more complex than needed, and a source of panic that was not obvious when testing.