### PR TITLE
test: enable EdDSA signature requets in pytests

### DIFF
--- a/pytest/common_lib/shared.py
+++ b/pytest/common_lib/shared.py
@@ -484,9 +484,6 @@ class MpcCluster:
         deposit = constants.SIGNATURE_DEPOSIT + (add_deposit or 0)
         domains = self.contract_state().get_running_domains()
         for domain in domains:
-            # todo: remove below lines to test signature requests for eddsa
-            if domain.scheme != 'Secp256k1':
-                continue
             print(
                 f"\033[91mGenerating \033[93m{requests_per_domains}\033[91m sign requests for {domain}.\033[0m"
             )

--- a/pytest/tests/test_web_endpoints.py
+++ b/pytest/tests/test_web_endpoints.py
@@ -32,7 +32,7 @@ def test_web_endpoints():
 
         response = requests.get(f'http://localhost:{port}/debug/blocks')
         assert 'Recent blocks:' in response.text, response.text
-        assert '1 sign reqs:' in response.text, response.text
+        assert '2 sign reqs:' in response.text, response.text
 
         response = requests.get(f'http://localhost:{port}/debug/signatures')
         assert 'Recent Signatures:' in response.text, response.text


### PR DESCRIPTION
Signature requests pass for EdDSA.


Tested with:
```bash
pytest tests/test_signature_request.py
```