### PR TITLE
Add CLI command to describe MPC cluster in devnet tool

### DIFF
--- a/devnet/src/cli.rs
+++ b/devnet/src/cli.rs
@@ -60,6 +60,9 @@ impl Cli {
                     MpcNetworkSubCmd::DestroyInfra(cmd) => {
                         cmd.run(&name, config).await;
                     }
+                    MpcNetworkSubCmd::Describe(cmd) => {
+                        cmd.run(&name, config).await;
+                    }
                 }
             }
             Cli::Loadtest(cmd) => {
@@ -126,6 +129,8 @@ pub enum MpcNetworkSubCmd {
     DeployNomad(MpcTerraformDeployNomadCmd),
     /// Destroy the GCP nodes previously deployed.
     DestroyInfra(MpcTerraformDestroyInfraCmd),
+    /// Prints out useful information about the contract and/or the deployed infra.
+    Describe(MpcDescribeCmd),
 }
 
 #[derive(clap::Parser)]
@@ -307,6 +312,9 @@ pub struct MpcTerraformDeployNomadCmd {
 
 #[derive(clap::Parser)]
 pub struct MpcTerraformDestroyInfraCmd {}
+
+#[derive(clap::Parser)]
+pub struct MpcDescribeCmd {}
 
 #[derive(clap::Parser)]
 pub struct NewLoadtestCmd {

--- a/devnet/src/mpc.rs
+++ b/devnet/src/mpc.rs
@@ -980,7 +980,7 @@ impl MpcDescribeCmd {
                     Self::print_parameters(&state.parameters);
                 }
                 ProtocolContractState::Resharing(state) => {
-                    println!("Contract is in Initializing state (key generation)");
+                    println!("Contract is in Resharing state");
                     println!(
                         "  Epoch transition: original {} --> prospective {}",
                         state.previous_running_state.keyset.epoch_id,

--- a/devnet/src/mpc.rs
+++ b/devnet/src/mpc.rs
@@ -931,6 +931,7 @@ impl MpcDescribeCmd {
                     println!("  Domains:");
                     for (i, domain) in state.domains.domains().iter().enumerate() {
                         print!("    Domain {}: {:?}, ", domain.id, domain.scheme);
+                        #[allow(clippy::comparison_chain)]
                         if i < state.generated_keys.len() {
                             println!(
                                 "key generated (attempt ID {})",
@@ -1001,6 +1002,7 @@ impl MpcDescribeCmd {
                             state.previous_running_state.keyset.domains[i].attempt
                         );
 
+                        #[allow(clippy::comparison_chain)]
                         if i < state.reshared_keys.len() {
                             println!("reshared (attempt ID {})", state.reshared_keys[i].attempt);
                         } else if i == state.reshared_keys.len() {

--- a/devnet/src/terraform/describe.rs
+++ b/devnet/src/terraform/describe.rs
@@ -1,0 +1,92 @@
+use serde::Deserialize;
+
+/// Partial JSON schema for `terraform show -json` output.
+#[derive(Deserialize)]
+pub(super) struct TerraformInfraShowOutput {
+    pub values: RootValues,
+}
+
+#[derive(Deserialize)]
+pub(super) struct RootValues {
+    pub root_module: RootModule,
+}
+
+#[derive(Deserialize)]
+pub(super) struct RootModule {
+    pub resources: Vec<Resource>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct Resource {
+    pub address: String,
+    #[serde(rename = "type")]
+    pub type_: String,
+    pub values: ResourceValues,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub(super) enum ResourceValues {
+    GoogleComputeInstance(GoogleComputeInstance),
+    Other(Other),
+}
+
+#[derive(Deserialize, Clone)]
+pub(super) struct GoogleComputeInstance {
+    pub machine_type: String,
+    pub network_interface: Vec<NetworkInterface>,
+    pub zone: String,
+}
+
+#[derive(Deserialize, Clone)]
+pub(super) struct NetworkInterface {
+    pub access_config: Vec<AccessConfig>,
+}
+
+#[derive(Deserialize, Clone)]
+pub(super) struct AccessConfig {
+    pub nat_ip: String,
+}
+
+#[derive(Deserialize, Clone)]
+pub(super) struct Other {}
+
+impl GoogleComputeInstance {
+    pub fn nat_ip(&self) -> Option<String> {
+        self.network_interface
+            .get(0)
+            .and_then(|ni| ni.access_config.get(0))
+            .map(|ac| ac.nat_ip.clone())
+    }
+}
+
+impl Resource {
+    pub fn as_mpc_nomad_client(&self) -> Option<(usize, GoogleComputeInstance)> {
+        let name_start = "google_compute_instance.nomad_client_mpc[";
+        if self.type_ == "google_compute_instance" && self.address.starts_with(name_start) {
+            let index: usize = self.address[name_start.len()..self.address.len() - 1]
+                .parse()
+                .unwrap();
+            if let ResourceValues::GoogleComputeInstance(instance) = &self.values {
+                Some((index, instance.clone()))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn as_mpc_nomad_server(&self) -> Option<GoogleComputeInstance> {
+        let name = "google_compute_instance.nomad_server";
+        if self.type_ == "google_compute_instance" && self.address == name {
+            if let ResourceValues::GoogleComputeInstance(instance) = &self.values {
+                Some(instance.clone())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/devnet/src/terraform/describe.rs
+++ b/devnet/src/terraform/describe.rs
@@ -54,8 +54,8 @@ pub(super) struct Other {}
 impl GoogleComputeInstance {
     pub fn nat_ip(&self) -> Option<String> {
         self.network_interface
-            .get(0)
-            .and_then(|ni| ni.access_config.get(0))
+            .first()
+            .and_then(|ni| ni.access_config.first())
             .map(|ac| ac.nat_ip.clone())
     }
 }

--- a/libs/chain-signatures/contract/src/primitives/domain.rs
+++ b/libs/chain-signatures/contract/src/primitives/domain.rs
@@ -2,6 +2,7 @@ use super::key_state::AuthenticatedParticipantId;
 use crate::errors::{DomainError, Error};
 use near_sdk::{log, near, CurveType};
 use std::collections::BTreeMap;
+use std::fmt::Display;
 
 /// Each domain corresponds to a specific root key in a specific signature scheme. There may be
 /// multiple domains per signature scheme. The domain ID uniquely identifies a domain.
@@ -19,6 +20,12 @@ impl DomainId {
     /// Returns the DomainId of the single ECDSA key present in the contract before V2.
     pub fn legacy_ecdsa_id() -> Self {
         Self(0)
+    }
+}
+
+impl Display for DomainId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/libs/chain-signatures/contract/src/primitives/key_state.rs
+++ b/libs/chain-signatures/contract/src/primitives/key_state.rs
@@ -3,6 +3,7 @@ use super::participants::{ParticipantId, Participants};
 use crate::crypto_shared::types::PublicKeyExtended;
 use crate::errors::{DomainError, Error, InvalidState};
 use near_sdk::{env, near};
+use std::fmt::Display;
 
 /// An EpochId uniquely identifies a ThresholdParameters (but not vice-versa).
 /// Every time we change the ThresholdParameters (participants and threshold),
@@ -22,6 +23,12 @@ impl EpochId {
     }
     pub fn get(&self) -> u64 {
         self.0
+    }
+}
+
+impl Display for EpochId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -47,6 +54,12 @@ impl AttemptId {
 impl Default for AttemptId {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Display for AttemptId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/libs/chain-signatures/contract/src/primitives/participants.rs
+++ b/libs/chain-signatures/contract/src/primitives/participants.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use near_sdk::{log, near, AccountId, PublicKey};
 use std::collections::BTreeSet;
+use std::fmt::Display;
 
 pub mod hpke {
     pub type PublicKey = [u8; 32];
@@ -36,6 +37,12 @@ impl ParticipantId {
     }
     pub fn next(&self) -> Self {
         ParticipantId(self.0 + 1)
+    }
+}
+
+impl Display for ParticipantId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 

--- a/libs/chain-signatures/contract/src/state/key_event.rs
+++ b/libs/chain-signatures/contract/src/state/key_event.rs
@@ -184,7 +184,7 @@ impl KeyEvent {
     }
 
     /// Returns whether an attempt is active ()and not timed out).
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn is_active(&self) -> bool {
         self.current_key_event_id().is_some()
     }


### PR DESCRIPTION
Example description:

```
MPC contract deployed at: mpc-contract-and-upg-4df70f9abb68.b892843ed20d.testnet
Contract is in Running state
  Epoch: 9
  Keyset:
	Domain 0: Secp256k1, key from attempt 0
	Domain 1: Ed25519, key from attempt 0
	Domain 2: Secp256k1, key from attempt 0
	Domain 3: Ed25519, key from attempt 0
	Domain 4: Secp256k1, key from attempt 0
	Domain 5: Ed25519, key from attempt 0
  Parameters:
	Participants:
  	ID 3: mpc-2-and-upg-c4c3bbdf00c0.andrei-devnet.testnet (http://mpc-node-2.service.mpc.consul:3000)
  	ID 4: mpc-1-and-upg-5a31c3d4ec91.andrei-devnet.testnet (http://mpc-node-1.service.mpc.consul:3000)
  	ID 5: mpc-0-and-upg-26b2094f1da5.andrei-devnet.testnet (http://mpc-node-0.service.mpc.consul:3000)
	Threshold: 3
Nomad server: http://35.203.145.20
Nomad client #0: zone us-west1-b, instance type n2d-standard-8, debug: http://34.169.182.161:8080/debug/tasks
Nomad client #1: zone us-west1-b, instance type n2d-standard-8, debug: http://34.105.100.13:8080/debug/tasks
Nomad client #2: zone us-west1-b, instance type n2d-standard-8, debug: http://34.83.175.21:8080/debug/tasks
```

Key generation:
```
Contract is in Initializing state (key generation)
  Epoch: 9
  Domains:
	Domain 0: Secp256k1, key generated (attempt ID 0)
	Domain 1: Ed25519, key generated (attempt ID 0)
	Domain 2: Secp256k1, key generated (attempt ID 0)
	Domain 3: Ed25519, key generated (attempt ID 0)
	Domain 4: Secp256k1, generating key: not active; next attempt ID: 0
	Domain 5: Ed25519, queued for generation
  Parameters:
	Participants:
  	ID 3: mpc-2-and-upg-c4c3bbdf00c0.andrei-devnet.testnet (http://mpc-node-2.service.mpc.consul:3000)
  	ID 4: mpc-1-and-upg-5a31c3d4ec91.andrei-devnet.testnet (http://mpc-node-1.service.mpc.consul:3000)
  	ID 5: mpc-0-and-upg-26b2094f1da5.andrei-devnet.testnet (http://mpc-node-0.service.mpc.consul:3000)
	Threshold: 3
```

Resharing:
```
Contract is in Resharing state
  Epoch transition: original 8 --> prospective 9
  Domains:
	Domain 0: Secp256k1, original key from attempt 0, reshared (attempt ID 0)
	Domain 1: Ed25519, original key from attempt 0, resharing key: active; current attempt ID: 0
	Domain 2: Secp256k1, original key from attempt 0, queued for resharing
  Previous Parameters:
	Participants:
  	ID 3: mpc-2-and-upg-c4c3bbdf00c0.andrei-devnet.testnet (http://mpc-node-2.service.mpc.consul:3000)
  	ID 4: mpc-1-and-upg-5a31c3d4ec91.andrei-devnet.testnet (http://mpc-node-1.service.mpc.consul:3000)
  	ID 5: mpc-0-and-upg-26b2094f1da5.andrei-devnet.testnet (http://mpc-node-0.service.mpc.consul:3000)
	Threshold: 2
  Proposed Parameters:
	Participants:
  	ID 3: mpc-2-and-upg-c4c3bbdf00c0.andrei-devnet.testnet (http://mpc-node-2.service.mpc.consul:3000)
  	ID 4: mpc-1-and-upg-5a31c3d4ec91.andrei-devnet.testnet (http://mpc-node-1.service.mpc.consul:3000)
  	ID 5: mpc-0-and-upg-26b2094f1da5.andrei-devnet.testnet (http://mpc-node-0.service.mpc.consul:3000)
	Threshold: 3
```