### PR TITLE
Upgrade nearcore to 2.6.0-rc.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,18 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if 1.0.0",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1161,9 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecheck"
@@ -1537,19 +1528,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.113.1"
+name = "cranelift-assembler-x64"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540b193ff98b825a1f250a75b3118911af918a734154c69d80bcfcf91e7e9522"
+checksum = "d2b83fcf2fc1c8954561490d02079b496fd0c757da88129981e15bfe3a548229"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7496a6e92b5cee48c5d772b0443df58816dee30fed6ba19b2a28e78037ecedf"
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.117.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a9dc0a8d3d49ee772101924968830f1c1937d650c571d3c2dd69dc36a68f41"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb269598b9557ab942d687d3c1086d77c4b50dcf35813f3a65ba306fd42279"
+checksum = "573c641174c40ef31021ae4a5a3ad78974e280633502d0dfc6e362385e0c100f"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1557,11 +1563,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46566d7c83a8bff4150748d66020f4c7224091952aa4b4df1ec4959c39d937a1"
+checksum = "2d7c94d572615156f2db682181cadbd96342892c31e08cc26a757344319a9220"
 dependencies = [
  "bumpalo",
+ "cranelift-assembler-x64",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-codegen-meta",
@@ -1570,43 +1577,47 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "log",
+ "pulley-interpreter",
  "regalloc2",
  "rustc-hash 2.1.1",
+ "serde",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df8a86a34236cc75a8a6a271973da779c2aeb36c43b6e14da474cf931317082"
+checksum = "beecd9fcf2c3e06da436d565de61a42676097ea6eb6b4499346ac6264b6bb9ce"
 dependencies = [
+ "cranelift-assembler-x64",
  "cranelift-codegen-shared",
+ "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf75340b6a57b7c7c1b74f10d3d90883ee6d43a554be8131a4046c2ebcf5eb65"
+checksum = "0f4ff8d2e1235f2d6e7fc3c6738be6954ba972cd295f09079ebffeca2f864e22"
 
 [[package]]
 name = "cranelift-control"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e84495bc5d23d86aad8c86f8ade4af765b94882af60d60e271d3153942f1978"
+checksum = "001312e9fbc7d9ca9517474d6fe71e29d07e52997fd7efe18f19e8836446ceb2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963c17147b80df351965e57c04d20dbedc85bcaf44c3436780a59a3f1ff1b1c2"
+checksum = "eb0fd6d4aae680275fcbceb08683416b744e65c8b607352043d3f0951d72b3b2"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1615,31 +1626,31 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727f02acbc4b4cb2ba38a6637101d579db50190df1dd05168c68e762851a3dd5"
+checksum = "9fd44e7e5dcea20ca104d45894748205c51365ce4cdb18f4418e3ba955971d1b"
 dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
 name = "cranelift-isle"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b00cc2e03c748f2531eea01c871f502b909d30295fdcad43aec7bf5c5b4667"
+checksum = "f900e0a3847d51eed0321f0777947fb852ccfce0da7fb070100357f69a2f37fc"
 
 [[package]]
 name = "cranelift-native"
-version = "0.113.1"
+version = "0.117.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbeaf978dc7c1a2de8bbb9162510ed218eb156697bc45590b8fbdd69bb08e8de"
+checksum = "7617f13f392ebb63c5126258aca8b8eca739636ca7e4eeee301d3eff68489a6a"
 dependencies = [
  "cranelift-codegen",
  "libc",
- "target-lexicon 0.12.16",
+ "target-lexicon 0.13.2",
 ]
 
 [[package]]
@@ -2804,17 +2815,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.11",
- "serde",
+ "ahash",
 ]
 
 [[package]]
@@ -2826,6 +2827,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -3261,12 +3263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3356,6 +3352,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "insta"
+version = "1.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "pin-project 1.1.10",
+ "serde",
+ "similar",
 ]
 
 [[package]]
@@ -3598,6 +3610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3608,6 +3626,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -3946,13 +3970,13 @@ dependencies = [
  "mpc-contract 1.0.1",
  "mpc-contract 2.0.0-alpha",
  "near-client",
- "near-config-utils 2.5.0-rc.1",
- "near-crypto 2.5.0-rc.1",
+ "near-config-utils 2.6.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-indexer",
  "near-indexer-primitives",
  "near-o11y",
  "near-sdk",
- "near-time 2.5.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "prometheus",
  "rand 0.8.5",
  "rand_xorshift",
@@ -4034,8 +4058,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "derive_more 1.0.0",
@@ -4043,7 +4067,7 @@ dependencies = [
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.5.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "once_cell",
  "serde",
  "serde_json",
@@ -4054,8 +4078,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4064,16 +4088,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "lru 0.12.5",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "anyhow",
@@ -4092,19 +4116,19 @@ dependencies = [
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-epoch-manager",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "near-store",
- "near-vm-runner 2.5.0-rc.1",
+ "near-vm-runner 2.6.0-rc.1",
  "node-runtime",
  "num-rational",
  "once_cell",
@@ -4122,19 +4146,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 1.0.0",
- "near-config-utils 2.5.0-rc.1",
- "near-crypto 2.5.0-rc.1",
+ "near-config-utils 2.6.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
- "near-primitives 2.5.0-rc.1",
- "near-time 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "num-rational",
  "serde",
  "serde_json",
@@ -4146,12 +4170,12 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
- "near-crypto 2.5.0-rc.1",
- "near-primitives 2.5.0-rc.1",
- "near-time 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "thiserror 2.0.12",
  "time",
  "tracing",
@@ -4159,8 +4183,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "borsh",
@@ -4173,14 +4197,14 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "near-store",
  "rand 0.8.5",
  "reed-solomon-erasure",
@@ -4191,17 +4215,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4222,19 +4246,19 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.5.0-rc.1",
+ "near-vm-runner 2.6.0-rc.1",
  "num-rational",
  "once_cell",
  "percent-encoding",
@@ -4260,17 +4284,17 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.5.0-rc.1",
- "near-primitives 2.5.0-rc.1",
- "near-time 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "serde",
  "serde_json",
  "strum 0.24.1",
@@ -4293,8 +4317,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -4329,8 +4353,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "blake2",
  "borsh",
@@ -4340,9 +4364,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
- "near-stdx 2.5.0-rc.1",
+ "near-config-utils 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
+ "near-stdx 2.6.0-rc.1",
  "primitive-types",
  "rand 0.8.5",
  "secp256k1",
@@ -4354,15 +4378,15 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-primitives 2.5.0-rc.1",
- "near-time 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "prometheus",
  "serde",
  "serde_json",
@@ -4373,18 +4397,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-primitives 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational",
@@ -4408,10 +4432,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
- "near-primitives-core 2.5.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
 ]
 
 [[package]]
@@ -4437,22 +4461,22 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.5.0-rc.1",
- "near-crypto 2.5.0-rc.1",
+ "near-config-utils 2.6.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-indexer-primitives",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
- "near-primitives 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -4465,18 +4489,18 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4490,11 +4514,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-jsonrpc-client",
+ "near-jsonrpc-client-internal",
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -4504,30 +4528,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-jsonrpc-client"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+name = "near-jsonrpc-client-internal"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.5.0-rc.1",
- "near-primitives 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4536,19 +4560,19 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "anyhow",
@@ -4568,13 +4592,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.5.0-rc.1",
- "near-fmt 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
+ "near-fmt 2.6.0-rc.1",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -4599,14 +4623,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.5.0-rc.1",
- "near-primitives-core 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -4643,14 +4667,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "num-rational",
  "serde",
  "serde_repr",
@@ -4661,8 +4685,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -4676,8 +4700,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4685,13 +4709,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "borsh",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "rand 0.8.5",
 ]
 
@@ -4737,8 +4761,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4753,13 +4777,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.5.0-rc.1",
- "near-fmt 2.5.0-rc.1",
- "near-parameters 2.5.0-rc.1",
- "near-primitives-core 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
- "near-stdx 2.5.0-rc.1",
- "near-time 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
+ "near-fmt 2.6.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
+ "near-stdx 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "num-rational",
  "ordered-float",
  "primitive-types",
@@ -4800,8 +4824,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -4810,7 +4834,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.5.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
  "num-rational",
  "serde",
  "serde_repr",
@@ -4820,8 +4844,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-cors",
@@ -4831,15 +4855,16 @@ dependencies = [
  "derive_more 1.0.0",
  "futures",
  "hex",
+ "insta",
  "near-account-id",
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
- "near-primitives 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "node-runtime",
  "paperclip",
  "serde",
@@ -4857,8 +4882,8 @@ checksum = "943ce3e4f7e8bf6ccd757dd4eb2bfa7de0fba198c4f53db86a5f4e03e807be7e"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -4872,11 +4897,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
- "near-schema-checker-core 2.5.0-rc.1",
- "near-schema-checker-macro 2.5.0-rc.1",
+ "near-schema-checker-core 2.6.0-rc.1",
+ "near-schema-checker-macro 2.6.0-rc.1",
 ]
 
 [[package]]
@@ -4887,8 +4912,8 @@ checksum = "d0906c4a3962bc31e9737da0884e3595065b37eb3117848c6d73be3746cc734b"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 
 [[package]]
 name = "near-sdk"
@@ -4940,13 +4965,13 @@ checksum = "9259168eb4953dddd96a27aafdeabae2c3909658ea66f60f6836859662cfdf2f"
 
 [[package]]
 name = "near-stdx"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 
 [[package]]
 name = "near-store"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4963,15 +4988,15 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.5.0-rc.1",
- "near-fmt 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
+ "near-fmt 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
- "near-primitives 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
- "near-stdx 2.5.0-rc.1",
- "near-time 2.5.0-rc.1",
- "near-vm-runner 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
+ "near-stdx 2.6.0-rc.1",
+ "near-time 2.6.0-rc.1",
+ "near-vm-runner 2.6.0-rc.1",
  "num_cpus",
  "rand 0.8.5",
  "rayon",
@@ -4981,9 +5006,11 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "static_assertions",
  "strum 0.24.1",
  "tempfile",
  "thiserror 2.0.12",
+ "thread_local",
  "tokio",
  "tracing",
 ]
@@ -4996,8 +5023,8 @@ checksum = "dbf4ca5c805cb78700e10e43484902d8da05f25788db277999d209568aaf4c8e"
 
 [[package]]
 name = "near-telemetry"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "awc",
@@ -5006,7 +5033,7 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.5.0-rc.1",
+ "near-time 2.6.0-rc.1",
  "openssl",
  "serde",
  "serde_json",
@@ -5025,8 +5052,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "serde",
  "time",
@@ -5045,8 +5072,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -5061,8 +5088,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -5081,8 +5108,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -5095,7 +5122,7 @@ dependencies = [
  "region",
  "rkyv 0.8.10",
  "rustc-demangle",
- "rustix 0.38.44",
+ "rustix 1.0.5",
  "target-lexicon 0.12.16",
  "thiserror 2.0.12",
  "tracing",
@@ -5135,8 +5162,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
  "blst",
@@ -5147,12 +5174,12 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
- "near-primitives-core 2.5.0-rc.1",
- "near-schema-checker-lib 2.5.0-rc.1",
- "near-stdx 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
+ "near-schema-checker-lib 2.6.0-rc.1",
+ "near-stdx 2.6.0-rc.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -5164,9 +5191,10 @@ dependencies = [
  "prefix-sum-vec",
  "prometheus",
  "pwasm-utils",
+ "rand 0.8.5",
  "rayon",
  "ripemd",
- "rustix 0.38.44",
+ "rustix 1.0.5",
  "serde",
  "serde_repr",
  "sha2",
@@ -5175,7 +5203,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.12",
  "tracing",
- "wasm-encoder 0.218.1",
+ "wasm-encoder 0.224.1",
  "wasmer-compiler-near",
  "wasmer-compiler-singlepass-near",
  "wasmer-engine-near",
@@ -5191,8 +5219,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "indexmap 2.8.0",
  "num-traits",
@@ -5202,8 +5230,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "backtrace",
  "cc",
@@ -5223,18 +5251,18 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.5.0-rc.1",
- "near-vm-runner 2.5.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
+ "near-vm-runner 2.6.0-rc.1",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5259,8 +5287,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.5.0-rc.1",
- "near-crypto 2.5.0-rc.1",
+ "near-config-utils 2.6.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -5268,14 +5296,14 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.5.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.5.0-rc.1",
+ "near-vm-runner 2.6.0-rc.1",
  "node-runtime",
  "num-rational",
  "rand 0.8.5",
@@ -5324,19 +5352,19 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.5.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=39882d8d34281fae2e5551c000eeeede2e75f8da#39882d8d34281fae2e5551c000eeeede2e75f8da"
+version = "2.6.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 dependencies = [
  "borsh",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.5.0-rc.1",
+ "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-parameters 2.5.0-rc.1",
- "near-primitives 2.5.0-rc.1",
- "near-primitives-core 2.5.0-rc.1",
+ "near-parameters 2.6.0-rc.1",
+ "near-primitives 2.6.0-rc.1",
+ "near-primitives-core 2.6.0-rc.1",
  "near-store",
- "near-vm-runner 2.5.0-rc.1",
+ "near-vm-runner 2.6.0-rc.1",
  "near-wallet-contract",
  "num-bigint 0.3.3",
  "num-traits",
@@ -5865,6 +5893,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6017,7 +6090,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6288,13 +6361,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33e7f8a43ccc7f93b330fef4baf271764674926f3f4d40f4a196d54de8af26"
+checksum = "cb0ecb9823083f71df8735f21f6c44f2f2b55986d674802831df20f27e26c907"
 dependencies = [
  "cranelift-bitset",
  "log",
- "sptr",
+ "wasmtime-math",
 ]
 
 [[package]]
@@ -6412,7 +6485,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6566,14 +6639,15 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.10.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
+checksum = "6d4c3c15aa088eccea44550bffea9e9a5d0b14a264635323d23c6e6351acca98"
 dependencies = [
- "hashbrown 0.14.5",
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.2",
  "log",
  "rustc-hash 2.1.1",
- "slice-group-by",
  "smallvec",
 ]
 
@@ -7018,6 +7092,19 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno 0.3.10",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7520,6 +7607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7560,12 +7653,6 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "slice-group-by"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
@@ -7872,6 +7959,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
@@ -8376,6 +8469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8627,11 +8726,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.218.1"
+version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491f7e48672d0a1efdeadf897d98ac1f45942c26c3829cb44a6b828f6f26155f"
+checksum = "1ab7a13a23790fe91ea4eb7526a1f3131001d874e3e00c2976c48861f2e82920"
 dependencies = [
  "leb128",
+ "wasmparser 0.224.1",
 ]
 
 [[package]]
@@ -8849,13 +8949,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.218.1"
+version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059739c2eac26eea736389a7d6d30b41a8201490bea204d0facde19183359849"
+checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
- "ahash 0.8.11",
  "bitflags 2.9.0",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "indexmap 2.8.0",
  "semver 1.0.26",
  "serde",
@@ -8873,30 +8972,30 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.218.1"
+version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b30ceafa77646f56747369b0f2a0296016a40b447d32e6907439f2e4bb7695"
+checksum = "0095b53a3b09cbc2f90f789ea44aa1b17ecc2dad8b267e657c7391f3ded6293d"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.218.1",
+ "wasmparser 0.224.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e762e163fd305770c6c341df3290f0cabb3c264e7952943018e9a1ced8d917"
+checksum = "809cc8780708f1deed0a7c3fcab46954f0e8c08a6fe0252772481fbc88fcf946"
 dependencies = [
+ "addr2line",
  "anyhow",
  "bitflags 2.9.0",
  "bumpalo",
  "cc",
  "cfg-if 1.0.0",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "indexmap 2.8.0",
  "libc",
- "libm",
  "log",
  "mach2",
  "memfd",
@@ -8911,13 +9010,14 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "sptr",
- "target-lexicon 0.12.16",
- "wasmparser 0.218.1",
+ "target-lexicon 0.13.2",
+ "wasmparser 0.224.1",
  "wasmtime-asm-macros",
- "wasmtime-component-macro",
  "wasmtime-cranelift",
  "wasmtime-environ",
+ "wasmtime-fiber",
  "wasmtime-jit-icache-coherence",
+ "wasmtime-math",
  "wasmtime-slab",
  "wasmtime-versioned-export-macros",
  "windows-sys 0.59.0",
@@ -8925,39 +9025,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63caa7aebb546374e26257a1900fb93579171e7c02514cde26805b9ece3ef812"
+checksum = "236964b6b35af0f08879c9c56dbfbc5adc12e8d624672341a0121df31adaa3fa"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
-name = "wasmtime-component-macro"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a4b5ce2ad9c15655e830f0eac0c38b8def30c74ecac71f452d3901e491b68"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser",
-]
-
-[[package]]
-name = "wasmtime-component-util"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e87a1212270dbb84a49af13d82594e00a92769d6952b0ea7fc4366c949f6ad"
-
-[[package]]
 name = "wasmtime-cranelift"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb40dddf38c6a5eefd5ce7c1baf43b00fe44eada11a319fab22e993a960262f"
+checksum = "abcc9179097235c91f299a8ff56b358ee921266b61adff7d14d6e48428954dd2"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -8970,19 +9049,20 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "object",
+ "pulley-interpreter",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon 0.13.2",
  "thiserror 1.0.69",
- "wasmparser 0.218.1",
+ "wasmparser 0.224.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613075e89e94a48c05862243c2b718eef1b9c337f51493ebf951e149a10fa19"
+checksum = "8e90f6cba665939381839bbf2ddf12d732fca03278867910348ef1281b700954"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -8995,17 +9075,32 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "target-lexicon 0.12.16",
- "wasm-encoder 0.218.1",
- "wasmparser 0.218.1",
- "wasmprinter 0.218.1",
+ "target-lexicon 0.13.2",
+ "wasm-encoder 0.224.1",
+ "wasmparser 0.224.1",
+ "wasmprinter 0.224.1",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5c2ac21f0b39d72d2dac198218a12b3ddeb4ab388a8fa0d2e429855876783c"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if 1.0.0",
+ "rustix 0.38.44",
+ "wasmtime-asm-macros",
+ "wasmtime-versioned-export-macros",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da47fba49af72581bc0dc67c8faaf5ee550e6f106e285122a184a675193701a5"
+checksum = "3f180cc0d2745e3a5df5d02231cd3046f49c75512eaa987b8202363b112e125d"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -9014,32 +9109,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-slab"
-version = "26.0.1"
+name = "wasmtime-math"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770e10cdefb15f2b6304152978e115bd062753c1ebe7221c0b6b104fa0419ff6"
+checksum = "f5f04c5dcf5b2f88f81cfb8d390294b2f67109dc4d0197ea7303c60a092df27c"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "30.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9681707f1ae9a4708ca22058722fca5c135775c495ba9b9624fe3732b94c97"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "26.0.1"
+version = "30.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8efb877c9e5e67239d4553bb44dd2a34ae5cfb728f3cf2c5e64439c6ca6ee7"
+checksum = "dd2fe69d04986a12fc759d2e79494100d600adcb3bb79e63dedfc8e6bb2ab03e"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bef2a726fd8d1ee9b0144655e16c492dc32eb4c7c9f7e3309fcffe637870933"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.8.0",
- "wit-parser",
 ]
 
 [[package]]
@@ -9438,24 +9530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-parser"
-version = "0.218.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f104473e8546f8096f1fa483d337101a98dc9525d67f4275816bcd177fe3e2be"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.8.0",
- "log",
- "semver 1.0.26",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.218.1",
-]
-
-[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9549,31 +9623,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.24",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -51,13 +51,13 @@ x509-parser = "0.16.0"
 
 curve25519-dalek = "4.1.3"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
-near-client = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
-near-config-utils = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
-near-crypto = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
-near-time = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-time = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
 # todo: update once 1.1.0 is pulbished (though the api did not change)
 legacy-mpc-contract = { package = "mpc-contract", git = "https://github.com/Near-One/mpc/", rev = "1d4954dff28e8eb988fb7762eff414a602a2b124" }
 mpc-contract = { path = "../libs/chain-signatures/contract/" }

--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -228,7 +228,10 @@ impl Coordinator {
                             }
                         }
                     }
-                    _ = self.indexer.contract_state_receiver.changed() => {
+                    res = self.indexer.contract_state_receiver.changed() => {
+                        if let Err(_) = res {
+                            anyhow::bail!("[{}] contract state receiver closed", job.name);
+                        }
                         if (job.stop_fn)(&self.indexer.contract_state_receiver.borrow()) {
                             tracing::info!(
                                 "[{}] contract state changed incompatibly, stopping",

--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -229,7 +229,7 @@ impl Coordinator {
                         }
                     }
                     res = self.indexer.contract_state_receiver.changed() => {
-                        if let Err(_) = res {
+                        if res.is_err() {
                             anyhow::bail!("[{}] contract state receiver closed", job.name);
                         }
                         if (job.stop_fn)(&self.indexer.contract_state_receiver.borrow()) {

--- a/node/src/indexer/mod.rs
+++ b/node/src/indexer/mod.rs
@@ -18,11 +18,13 @@ use tokio::sync::{mpsc, watch};
 use types::ChainSendTransactionRequest;
 
 pub(crate) struct IndexerState {
-    /// ViewClientActor address
+    /// For querying blockchain state.
     view_client: actix::Addr<near_client::ViewClientActor>,
-    /// ClientActor address
+    /// For querying blockchain sync status.
     client: actix::Addr<near_client::ClientActor>,
-    /// AccountId for the mpc contract
+    /// For sending txs to the chain.
+    tx_processor: actix::Addr<near_client::TxRequestHandlerActor>,
+    /// AccountId for the mpc contract.
     mpc_contract_id: AccountId,
 }
 
@@ -30,11 +32,13 @@ impl IndexerState {
     pub fn new(
         view_client: actix::Addr<near_client::ViewClientActor>,
         client: actix::Addr<near_client::ClientActor>,
+        tx_processor: actix::Addr<near_client::TxRequestHandlerActor>,
         mpc_contract_id: AccountId,
     ) -> Self {
         Self {
             view_client,
             client,
+            tx_processor,
             mpc_contract_id,
         }
     }

--- a/node/src/indexer/tx_sender.rs
+++ b/node/src/indexer/tx_sender.rs
@@ -50,7 +50,7 @@ async fn submit_tx(
     );
 
     let response = indexer_state
-        .client
+        .tx_processor
         .send(
             near_client::ProcessTxRequest {
                 transaction,

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -489,11 +489,11 @@ impl NetworkTaskChannelSender {
     /// This should be called at the beginning of the computation if:
     ///  - This is a leader-centric computation, and we are a follower.
     ///    (Rationale: the leader already determined that the participants are online. We wait
-    ///     for connections because even though the leader has connected to everyone, it is
-    ///     possible we have yet to establish connections to everyone. We assume that if the
-    ///     leader can connect to two nodes B and C, then B and C can also connect to each other.
-    ///     If it happens that a node is actually unavailable, then the leader would realize that
-    ///     too, and abort the computation.)
+    ///    for connections because even though the leader has connected to everyone, it is
+    ///    possible we have yet to establish connections to everyone. We assume that if the
+    ///    leader can connect to two nodes B and C, then B and C can also connect to each other.
+    ///    If it happens that a node is actually unavailable, then the leader would realize that
+    ///    too, and abort the computation.)
     ///
     /// This should NOT be called if:
     ///  - We are the leader. This is redundant because the leader already queried the alive

--- a/pytest/common_lib/shared.py
+++ b/pytest/common_lib/shared.py
@@ -671,8 +671,8 @@ def verify_txs(results, verification_callback, verbose=False):
 
 
 # Output is deserializable into the rust type near_crypto::SecretKey
-def serialize_key(key):
-    full_key = bytes(key.decoded_sk()) + bytes(key.decoded_pk())
+def serialize_key(key: Key):
+    full_key = bytes(key.decoded_sk())
     return 'ed25519:' + base58.b58encode(full_key).decode('ascii')
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,4 @@
 [toolchain]
-# This specifies the version of Rust we use to build.
-# Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
-# The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
-channel = "1.84.0"
+# This needs to be at least as high as the nearcore's toolchain version.
+channel = "1.86.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]


### PR DESCRIPTION
Also fix:
* Coordinator busy loops forever if indexer crashes. (We found it!)
* pytest used incorrect serialization of ed25519 secret key. (How did it work before?)