### PR TITLE
Update README for devnet V2; tie loose ends for devnet V2.

### DIFF
--- a/devnet/README.md
+++ b/devnet/README.md
@@ -28,7 +28,7 @@ edit it:
       - ed25519:xxxxxx  # Your private key
     kind: funding_account
   ```
-  If not provided, the devnet will create a funding account from the testnet faucet.
+  If not provided, the devnet will create funding accounts as needed from the testnet faucet.
 
 ## How the CLI Works
 This CLI is somewhat similar to Terraform in spirit. As soon as you
@@ -49,7 +49,6 @@ your username in there.
 ```
 target/debug/devnet mpc my-test new \
   --num-participants 2 \
-  --threshold 2 \
   --num-responding-access-keys 8 \
   --near-per-responding-account 1
 ```
@@ -60,8 +59,12 @@ independent nonce.
 Then, deploy the contract.
 ```
 target/debug/devnet mpc my-test deploy-contract \
-  --init-participants 2
+  --init-participants 2 --threshold 2
 ```
+
+Note: For V2, the `--v2` argument is needed. (TODO(#357): After V2 is released,
+change this to "For legacy V1, the `--v1` argument is needed.")
+
 The `--init-participants` can be fewer than the total number of participants,
 if we wish to have fewer participants join the network at the beginning.
 
@@ -86,31 +89,146 @@ the workspace name is the same as the MPC network name. The Terraform
 state is stored in S3, which is why this workspace name needs to be
 unique in the team.
 
-### Adding or removing nodes
+### Generating Keys
 
-The network can be updated with the following command. Any parameter
-specified via `new` can be overridden here, and the command will expand 
-the current setup to add any new resources.
+When first deployed, the contract has no keys. In order to make any signatures,
+we must first generate some keys. This example generates two keys, one for
+each signature scheme. You can specify duplicate schemes here as well if you wish
+to add multiple keys for each scheme.
+
+```
+target/debug/devnet mpc my-test vote-add-domains --signature-schemes Secp256k1,Ed25519
+```
+
+This triggers the MPC nodes to start performing key generation, after which the
+contract will transition into the Running state, ready for signatures.
+
+### Checking the Network State
+
+You can use the following command to print out the network state:
+```
+target/debug/devnet mpc my-test describe
+```
+
+This will print out the state of the contract as well as some debugging links from
+the cluster's nodes, e.g.
+
+```
+MPC contract deployed at: mpc-contract-and-upg-4df70f9abb68.b892843ed20d.testnet
+Contract is in Running state
+  Epoch: 9
+  Keyset:
+	Domain 0: Secp256k1, key from attempt 0
+	Domain 1: Ed25519, key from attempt 0
+	Domain 2: Secp256k1, key from attempt 0
+	Domain 3: Ed25519, key from attempt 0
+	Domain 4: Secp256k1, key from attempt 0
+	Domain 5: Ed25519, key from attempt 0
+  Parameters:
+	Participants:
+  	ID 3: mpc-2-and-upg-c4c3bbdf00c0.andrei-devnet.testnet (http://mpc-node-2.service.mpc.consul:3000)
+  	ID 4: mpc-1-and-upg-5a31c3d4ec91.andrei-devnet.testnet (http://mpc-node-1.service.mpc.consul:3000)
+  	ID 5: mpc-0-and-upg-26b2094f1da5.andrei-devnet.testnet (http://mpc-node-0.service.mpc.consul:3000)
+	Threshold: 3
+Nomad server: http://35.203.145.20
+Nomad client #0: zone us-west1-b, instance type n2d-standard-8, debug: http://34.169.182.161:8080/debug/tasks
+Nomad client #1: zone us-west1-b, instance type n2d-standard-8, debug: http://34.105.100.13:8080/debug/tasks
+Nomad client #2: zone us-west1-b, instance type n2d-standard-8, debug: http://34.83.175.21:8080/debug/tasks
+```
+
+### Sending Signatures
+
+See the section below on loadtesting.
+
+### Modifying the Network
+#### Adding more nodes, add access keys, etc.
+
+Any parameter specified via `new` can be overridden here, and the command
+will expand the current setup to add any new resources, for example:
 ```
 target/debug/devnet mpc my-test update --num-participants 3
 ```
-
-This only creates the new participant account. We still need to call join:
-```
-target/debug/devnet mpc my-test join --account-index 2
-```
-
-And then ask everyone else to vote join:
-```
-target/debug/devnet mpc my-test vote-join --for-account-index 2
-```
-
-Once that is all done, we can again run the deployment commands.
 
 Note that it is recommended to create all the participants that we're
 going to need upfront, instead of adding one later. The contract can be
 initialized with fewer participants and then new participants can join
 later, but creating all the machines upfront will save time.
+
+#### Adding or removing participants
+
+Suppose the network currently has 5 nodes, and the contract was initialized with 4 nodes.
+That means nodes [0, 1, 2, 3] are currently participating in the network. Suppose then we
+want node 4 and 5 to join, node 1 to leave, and also adjust the threshold to 4. We can do this:
+
+```
+target/debug/devnet mpc my-test vote-new-parameters --add 4 --add 5 --remove 1 --set-threshold 4
+```
+
+This will kick off a resharing operation to reshare all keys.
+
+#### Upgrading the contract
+To upgrade the contract, first propose the upgrade (suppose we wish to use the newly compiled
+contract code for the upgrade):
+```
+target/debug/devnet mpc my-test propose-update-contract --path ../libs/chain-signatures/target/wasm32-unknown-unknown/release/mpc_contract.wasm
+```
+this will print out a command to run for voting for the upgrade:
+```
+target/debug/devnet mpc my-test vote-update --update-id=0
+```
+That will trigger a migration to use the new contract.
+
+#### Using a different MPC node binary
+If we wish to change the MPC node binary, deploy a new docker image and then redeploy
+with the docker image tag, e.g.
+```
+target/debug/devnet mpc my-test deploy-nomad --docker-image nearone/mpc-node-gcp:my-test-1234567
+```
+
+### Cleaning up the Infra
+After you're done with testing the cluster, please bring down the machines to save resources:
+```
+target/debug/devnet mpc my-test destroy-infra
+```
+
+Also, you need to clear the deployed contract from local state, because the infra contains
+locally stored keyshares, and once we clear that, the contract state is effectively useless.
+```
+target/debug/devnet mpc my-test remove-contract
+```
+
+You may resume testing next time by using `deploy-contract` and then `deploy-infra` again.
+
+### Resetting the Contract without Resetting the Cluster
+At times, it may be useful to restart the contract from the initial state. We first need to
+remove and redeploy the contract like above, but also we need to reset the data for the nodes:
+```
+target/debug/devnet mpc my-test deploy-nomad --shutdown-and-reset
+```
+Check the Nomad pages for the reset jobs to complete, and then
+```
+target/debug/devnet mpc my-test deploy-nomad
+```
+This will clear all the local data on the nodes except the near blockchain data. That way,
+the effect is similar to remaking the cluster, but without having to wait for state sync again.
+
+### Legacy V1 instructions
+
+The legacy V1 contract only supports one key (secp256k1), and so the `vote-add-domains` step
+should be skipped.
+
+For adding nodes to the participant set, we need to first call join:
+```
+target/debug/devnet mpc my-test join --account-index 2
+```
+
+And then have everyone vote_join:
+```
+target/debug/devnet mpc my-test vote-join --for-account-index 2
+```
+
+#### Testing V1 -> V2 Upgrade
+See the description of https://github.com/Near-One/mpc/pull/349 .
 
 ## Creating a Loadtest Setup
 Create a loadtest set of accounts: (The name does **not** need to be
@@ -145,7 +263,13 @@ We can point the loadtest setup against the MPC contract:
 target/debug/devnet loadtest my-test run \
   --mpc-network my-test \
   --qps 20 \
-  --signatures-per-contract-call 10
+  --signatures-per-contract-call 10 \
+  --domain-id 0
 ```
-The last parameter is optional; if not specified, we will send one sign
-call per transaction.
+The `--signatures-per-contract-call` parameter is optional; if not
+specified, we will send one sign call per transaction. This parameter is useful
+if we want to send a high amount of load.
+
+The `--domain-id` parameter specifies which key to use for the signature
+requests. For V1, this parameter should be omitted to use the legacy API. For
+V2, this parameter *may* be omitted to test compatibility with the legacy API.

--- a/devnet/src/cli.rs
+++ b/devnet/src/cli.rs
@@ -162,9 +162,6 @@ pub struct NewMpcNetworkCmd {
     /// because initializing new machines is slow.
     #[clap(long)]
     pub num_participants: usize,
-    /// The threshold to initialize the contract with.
-    #[clap(long)]
-    pub threshold: usize,
     /// The amount of NEAR to give to each MPC account. This is NOT the account that will be used
     /// to send signature responses, so you do NOT need to give a lot to these accounts.
     #[clap(long, default_value = "1")]
@@ -184,8 +181,6 @@ pub struct UpdateMpcNetworkCmd {
     #[clap(long)]
     pub num_participants: Option<usize>,
     #[clap(long)]
-    pub threshold: Option<usize>,
-    #[clap(long)]
     pub near_per_account: Option<u128>,
     #[clap(long)]
     pub num_responding_access_keys: Option<usize>,
@@ -196,15 +191,19 @@ pub struct UpdateMpcNetworkCmd {
 #[derive(clap::Parser)]
 pub struct MpcDeployContractCmd {
     /// File path that contains the contract code.
-    #[clap(
-        long,
-        default_value = "../libs/chain-signatures/compiled-contracts/v1.0.1.wasm"
-    )]
-    pub path: String,
+    /// The default is `constants::DEFAULT_MPC_CONTRACT_PATH`.
+    #[clap(long)]
+    pub path: Option<String>,
+    /// TODO(#357): Change this flag to --v1 when v2 is released.
+    #[clap(long)]
+    pub v2: bool,
     /// The number of participants to initialize with; the participants will be from 0 to
     /// init_participants-1.
     #[clap(long)]
     pub init_participants: usize,
+    /// The threshold to initialize with.
+    #[clap(long)]
+    pub threshold: u64,
     /// The number of NEAR to deposit into the contract account, for storage deposit.
     #[clap(long, default_value = "20")]
     pub deposit_near: u128,
@@ -302,10 +301,11 @@ pub struct MpcTerraformDeployInfraCmd {
 
 #[derive(clap::Parser)]
 pub struct MpcTerraformDeployNomadCmd {
-    /// If true, shuts down the nodes and deletes the database.
+    /// If true, shuts down and reset the MPC nodes, leaving only the nearcore data.
     #[clap(long)]
-    pub shutdown_and_reset_db: bool,
+    pub shutdown_and_reset: bool,
     /// Overrides the docker image to use for MPC nodes.
+    /// The default is `constants::DEFAULT_MPC_DOCKER_IMAGE`.
     #[clap(long)]
     pub docker_image: Option<String>,
 }
@@ -351,11 +351,9 @@ pub struct UpdateLoadtestCmd {
 #[derive(clap::Parser)]
 pub struct DeployParallelSignContractCmd {
     /// File path that contains the parallel signature request contract code.
-    #[clap(
-        long,
-        default_value = "../pytest/tests/test_contracts/parallel/res/contract.wasm"
-    )]
-    pub path: String,
+    /// Defaults to `constants::DEFAULT_PARALLEL_SIGN_CONTRACT_PATH`.
+    #[clap(long)]
+    pub path: Option<String>,
     #[clap(long, default_value = "2")]
     pub deposit_near: u128,
 }

--- a/devnet/src/constants.rs
+++ b/devnet/src/constants.rs
@@ -5,3 +5,14 @@ pub const MINIMUM_BALANCE_TO_REMAIN_IN_ACCOUNTS: u128 = ONE_NEAR / 10;
 /// refill it if it's more than this percent of the desired balance. That way, we don't
 /// end up topping up accounts all the time with tiny amounts.
 pub const PERCENT_OF_ORIGINAL_BALANCE_BELOW_WHICH_TO_REFILL: u128 = 70;
+
+// TODO(#357): Update the following constants once V2 is released.
+
+/// The default contract to use.
+pub const DEFAULT_MPC_CONTRACT_PATH: &str =
+    "../libs/chain-signatures/compiled-contracts/v1.0.1.wasm";
+/// The default docker image to deploy the node with.
+pub const DEFAULT_MPC_DOCKER_IMAGE: &str = "nearone/mpc-node-gcp:testnet-release";
+/// The default parallel signing contract path to test with.
+pub const DEFAULT_PARALLEL_SIGN_CONTRACT_PATH: &str =
+    "../pytest/tests/test_contracts/parallel/res/contract.wasm";

--- a/devnet/src/types.rs
+++ b/devnet/src/types.rs
@@ -53,7 +53,6 @@ pub struct DevnetSetupRepository {
 pub struct MpcNetworkSetup {
     pub participants: Vec<AccountId>,
     pub contract: Option<AccountId>,
-    pub threshold: usize,
     // These desired fields are used when updating the network.
     pub desired_balance_per_account: u128,
     pub num_responding_access_keys: usize,


### PR DESCRIPTION
- Update README (defaulting to instructions for testing V2, but including legacy V1 instructions).
- Introduce constants for docker image, contract path, and parallel signing contract path, to use as defaults. When we release V2, we should update these.
- Make `deploy-contract` command use the correct `init()` parameters for V2.
- Support parallel signing contract V2.
- Move `threshold` parameter to the `deploy-contract` call; it makes more sense there.