### PR TITLE
Smart contract "proposal updates" logic improvements

### DIFF
--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -18,8 +18,7 @@ use crypto_shared::{
     types::SignatureResponse,
 };
 use errors::{
-    DomainError, InvalidParameters, InvalidState, PublicKeyError, RespondError,
-    SignError,
+    DomainError, InvalidParameters, InvalidState, PublicKeyError, RespondError, SignError,
 };
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::elliptic_curve::PrimeField;

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -8,7 +8,7 @@ pub mod storage_keys;
 pub mod update;
 
 use crate::errors::Error;
-use crate::update::{ProposeUpdateArgs, ProposedUpdates, UpdateId};
+use crate::update::{ProposeUpdateArgs, ProposedUpdates, Update, UpdateId};
 use config::{Config, InitConfig};
 use crypto_shared::types::{PublicKeyExtended, PublicKeyExtendedConversionError};
 use crypto_shared::{
@@ -18,7 +18,7 @@ use crypto_shared::{
     types::SignatureResponse,
 };
 use errors::{
-    ConversionError, DomainError, InvalidParameters, InvalidState, PublicKeyError, RespondError,
+    DomainError, InvalidParameters, InvalidState, PublicKeyError, RespondError,
     SignError,
 };
 use k256::elliptic_curve::sec1::ToEncodedPoint;
@@ -598,6 +598,7 @@ impl VersionedMpcContract {
         }
     }
 
+    /// Propose update to either code or config, but not both of them at the same time.
     #[payable]
     #[handle_result]
     pub fn propose_update(
@@ -606,9 +607,10 @@ impl VersionedMpcContract {
     ) -> Result<UpdateId, Error> {
         // Only voters can propose updates:
         let proposer = self.voter_or_panic();
+        let update: Update = args.try_into()?;
 
         let attached = env::attached_deposit();
-        let required = ProposedUpdates::required_deposit(&args.code, &args.config);
+        let required = ProposedUpdates::required_deposit(&update);
         if attached < required {
             return Err(InvalidParameters::InsufficientDeposit.message(format!(
                 "Attached {}, Required {}",
@@ -617,10 +619,7 @@ impl VersionedMpcContract {
             )));
         }
 
-        let Some(id) = self.proposed_updates().propose(args.code, args.config) else {
-            return Err(ConversionError::DataConversion
-                .message("Cannot propose update due to incorrect parameters."));
-        };
+        let id = self.proposed_updates().propose(update);
 
         log!(
             "propose_update: signer={}, id={:?}",
@@ -628,7 +627,7 @@ impl VersionedMpcContract {
             id,
         );
 
-        // Refund the difference if the propser attached more than required.
+        // Refund the difference if the proposer attached more than required.
         if let Some(diff) = attached.checked_sub(required) {
             if diff > NearToken::from_yoctonear(0) {
                 Promise::new(proposer).transfer(diff);

--- a/libs/chain-signatures/contract/src/storage_keys.rs
+++ b/libs/chain-signatures/contract/src/storage_keys.rs
@@ -13,4 +13,5 @@ pub enum StorageKey {
     /// Pending signature requests.
     PendingRequestsV2,
     ProposedUpdatesEntriesV2,
+    ProposedUpdatesVotesV2,
 }

--- a/libs/chain-signatures/contract/src/update.rs
+++ b/libs/chain-signatures/contract/src/update.rs
@@ -148,8 +148,9 @@ impl ProposedUpdates {
     pub fn do_update(&mut self, id: &UpdateId, gas: Gas) -> Option<Promise> {
         let entry = self.entries.remove(id)?;
 
-        // Clear other entries as they might be no longer valid
+        // Clear all entries as they might be no longer valid
         self.entries.clear();
+        self.vote_by_participant.clear();
 
         let mut promise = Promise::new(env::current_account_id());
         match entry.update {

--- a/libs/chain-signatures/contract/src/update.rs
+++ b/libs/chain-signatures/contract/src/update.rs
@@ -8,6 +8,7 @@ use borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::store::IterableMap;
 use near_sdk::{env, near, AccountId, Gas, NearToken, Promise};
+use crate::errors::{ConversionError, Error};
 
 #[derive(
     Copy,
@@ -54,13 +55,31 @@ pub struct ProposeUpdateArgs {
     pub config: Option<Config>,
 }
 
+impl TryFrom<ProposeUpdateArgs> for Update {
+    type Error = Error;
+
+    fn try_from(value: ProposeUpdateArgs) -> Result<Self, Self::Error> {
+        let ProposeUpdateArgs { code, config } = value;
+        let update = match (code, config) {
+            (Some(contract), None) => Update::Contract(contract),
+            (None, Some(config)) => Update::Config(config),
+            (Some(_), Some(_)) => return Err(
+                ConversionError::DataConversion
+                    .message("Code and config updates are not allowed at the same time")
+            ),
+            _ => return Err(
+                ConversionError::DataConversion
+                    .message("Expected either code or config update, received none of them")
+            ),
+        };
+        Ok(update)
+    }
+}
+
 #[near(serializers=[borsh ])]
 #[derive(Debug)]
 struct UpdateEntry {
-    // todo:
-    // - allow only one vote per participant.
-    // - an update should be either a code update, or a config update, not both.
-    updates: Vec<Update>,
+    update: Update,
     votes: HashSet<AccountId>,
     bytes_used: u128,
 }
@@ -68,6 +87,7 @@ struct UpdateEntry {
 #[near(serializers=[borsh ])]
 #[derive(Debug)]
 pub struct ProposedUpdates {
+    vote_by_participant: IterableMap<AccountId, UpdateId>,
     entries: IterableMap<UpdateId, UpdateEntry>,
     id: UpdateId,
 }
@@ -75,6 +95,7 @@ pub struct ProposedUpdates {
 impl Default for ProposedUpdates {
     fn default() -> Self {
         Self {
+            vote_by_participant: IterableMap::new(StorageKey::ProposedUpdatesVotesV2),
             entries: IterableMap::new(StorageKey::ProposedUpdatesEntriesV2),
             id: UpdateId::default(),
         }
@@ -82,94 +103,94 @@ impl Default for ProposedUpdates {
 }
 
 impl ProposedUpdates {
-    pub fn required_deposit(code: &Option<Vec<u8>>, config: &Option<Config>) -> NearToken {
-        required_deposit(bytes_used(code, config))
+    pub fn required_deposit(update: &Update) -> NearToken {
+        required_deposit(bytes_used(update))
     }
 
     /// Propose an update given the new contract code and/or config.
     ///
-    /// Returns Some(UpdateId) if the update was successfully proposed, otherwise None.
-    pub fn propose(&mut self, code: Option<Vec<u8>>, config: Option<Config>) -> Option<UpdateId> {
-        let bytes_used = bytes_used(&code, &config);
-        let updates = match (code, config) {
-            (Some(contract), Some(config)) => {
-                vec![Update::Contract(contract), Update::Config(config)]
-            }
-            (Some(contract), None) => vec![Update::Contract(contract)],
-            (None, Some(config)) => vec![Update::Config(config)],
-            (None, None) => return None,
-        };
+    /// Returns UpdateId
+    pub fn propose(&mut self, update: Update) -> UpdateId {
+        let bytes_used = bytes_used(&update);
 
         let id = self.id.generate();
         self.entries.insert(
             id,
             UpdateEntry {
-                updates,
+                update,
                 votes: HashSet::new(),
                 bytes_used,
             },
         );
 
-        Some(id)
+        id
     }
 
     /// Vote for the update with the given id.
     ///
     /// Returns Some(votes) if the given [`UpdateId`] exists, otherwise None.
     pub fn vote(&mut self, id: &UpdateId, voter: AccountId) -> Option<&HashSet<AccountId>> {
+        // If participant has voted before, remove their vote
+        if let Some(previous_id) = self.vote_by_participant.get(&voter) {
+            self
+                .entries
+                .get_mut(&previous_id)?
+                .votes
+                .remove(&voter);
+        }
+        self.vote_by_participant.insert(voter.clone(), *id);
+
         let entry = self.entries.get_mut(id)?;
         entry.votes.insert(voter);
         Some(&entry.votes)
     }
 
-    fn remove(&mut self, id: &UpdateId) -> Option<UpdateEntry> {
-        self.entries.remove(id)
-    }
-
     pub fn do_update(&mut self, id: &UpdateId, gas: Gas) -> Option<Promise> {
-        let entry = self.remove(id)?;
+        let entry = self.entries.remove(id)?;
+
+        // Clear other entries as they might be no longer valid
+        self.entries.clear();
 
         let mut promise = Promise::new(env::current_account_id());
-        for update in entry.updates {
-            // does it make sense to update both code & config
-            // simultaneously?
-            match update {
-                Update::Contract(code) => {
-                    // deploy contract then do a `migrate` call to migrate state.
-                    promise = promise.deploy_contract(code).function_call(
-                        "migrate".into(),
-                        Vec::new(),
-                        NearToken::from_near(0),
-                        gas,
-                    );
-                }
-                Update::Config(config) => {
-                    promise = promise.function_call(
-                        "update_config".into(),
-                        serde_json::to_vec(&(&config,)).unwrap(),
-                        NearToken::from_near(0),
-                        gas,
-                    );
-                }
+        match entry.update {
+            Update::Contract(code) => {
+                // deploy contract then do a `migrate` call to migrate state.
+                promise = promise.deploy_contract(code).function_call(
+                    "migrate".into(),
+                    Vec::new(),
+                    NearToken::from_near(0),
+                    gas,
+                );
+            }
+            Update::Config(config) => {
+                promise = promise.function_call(
+                    "update_config".into(),
+                    serde_json::to_vec(&(&config,)).unwrap(),
+                    NearToken::from_near(0),
+                    gas,
+                );
             }
         }
         Some(promise)
     }
 }
 
-fn bytes_used(code: &Option<Vec<u8>>, config: &Option<Config>) -> u128 {
+fn bytes_used(update: &Update) -> u128 {
     let mut bytes_used = std::mem::size_of::<UpdateEntry>() as u128;
 
     // Assume a high max of 128 participant votes per update entry.
     bytes_used += 128 * std::mem::size_of::<AccountId>() as u128;
 
-    if let Some(config) = config {
-        let bytes = serde_json::to_vec(&config).unwrap();
-        bytes_used += bytes.len() as u128;
+    match update {
+        Update::Contract(code) => {
+            bytes_used += code.len() as u128;
+        }
+        Update::Config(config) => {
+            let bytes = serde_json::to_vec(&config).unwrap();
+            bytes_used += bytes.len() as u128;
+        }
     }
-    if let Some(code) = code {
-        bytes_used += code.len() as u128;
-    }
+
     bytes_used
 }
 

--- a/libs/chain-signatures/contract/tests/common.rs
+++ b/libs/chain-signatures/contract/tests/common.rs
@@ -378,11 +378,15 @@ pub async fn vote_update_till_completion(
             .await
             .unwrap();
 
-        // Met the threshold, voting completed.
-        if execution.is_failure() {
-            break;
+        dbg!(&execution);
+
+        let update_occurred: bool = execution.json().expect("Vote cast was unsuccessful");
+
+        if update_occurred {
+            return;
         }
     }
+    panic!("Update didn't occurred")
 }
 
 pub fn check_call_success(result: ExecutionFinalResult) {

--- a/libs/chain-signatures/contract/tests/updates.rs
+++ b/libs/chain-signatures/contract/tests/updates.rs
@@ -4,7 +4,6 @@ use mpc_contract::config::Config;
 use mpc_contract::state::ProtocolContractState;
 use mpc_contract::update::{ProposeUpdateArgs, UpdateId};
 use near_workspaces::types::NearToken;
-use crate::common::accounts;
 
 pub fn dummy_contract() -> ProposeUpdateArgs {
     ProposeUpdateArgs {
@@ -256,7 +255,6 @@ async fn test_propose_update_contract_many() {
     dbg!(state);
 }
 
-
 #[tokio::test]
 async fn test_propose_incorrect_updates() {
     let (_, contract, accounts, _) = init_env_secp256k1(1).await;
@@ -366,8 +364,8 @@ async fn only_one_vote_from_participant() {
     let execution = accounts[0]
         .call(contract.id(), "vote_update")
         .args_json(serde_json::json!({
-                "id": proposal_a,
-            }))
+            "id": proposal_a,
+        }))
         .max_gas()
         .transact()
         .await
@@ -380,8 +378,8 @@ async fn only_one_vote_from_participant() {
     let execution = accounts[0]
         .call(contract.id(), "vote_update")
         .args_json(serde_json::json!({
-                "id": proposal_b,
-            }))
+            "id": proposal_b,
+        }))
         .max_gas()
         .transact()
         .await
@@ -394,8 +392,8 @@ async fn only_one_vote_from_participant() {
     let execution = accounts[1]
         .call(contract.id(), "vote_update")
         .args_json(serde_json::json!({
-                "id": proposal_a,
-            }))
+            "id": proposal_a,
+        }))
         .max_gas()
         .transact()
         .await
@@ -408,8 +406,8 @@ async fn only_one_vote_from_participant() {
     let execution = accounts[1]
         .call(contract.id(), "vote_update")
         .args_json(serde_json::json!({
-                "id": proposal_b,
-            }))
+            "id": proposal_b,
+        }))
         .max_gas()
         .transact()
         .await


### PR DESCRIPTION
Resolves #329
Resolves #318

* Accept update proposals which are only modifies code, or config, but not both.
* A participant's vote can be counted only once for some proposal. If participant votes again, transfer vote from one proposal to the other
* Remove all proposals after update
* Add tests for introduced code paths 