### PR TITLE
chore: Add metrics for latency of signature request responses.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8224,6 +8224,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -41,7 +41,7 @@ serde_yaml = "0.9.34"
 sha3 = "0.10.8"
 tempfile = "=3.14.0"
 tokio = { version = "1.41.0", features = ["full"] }
-tokio-util = "0.7.12"
+tokio-util = { version = "0.7.12", features = ["time"] }
 tokio-rustls = { version = "0.26.1", default-features = false }
 tokio-stream = { version = "0.1" }
 tracing = "0.1.40"

--- a/node/src/indexer/respond_metrics.rs
+++ b/node/src/indexer/respond_metrics.rs
@@ -1,0 +1,1 @@
+pub(crate) async fn monitor_requests() {}

--- a/node/src/indexer/respond_metrics.rs
+++ b/node/src/indexer/respond_metrics.rs
@@ -1,1 +1,0 @@
-pub(crate) async fn monitor_requests() {}

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -208,7 +208,7 @@ lazy_static! {
 }
 
 lazy_static! {
-    pub static ref SIGNATURE_REQUEST_BLOCK_DELAY: prometheus::Histogram = {
+    pub static ref SIGNATURE_REQUEST_RESPONSE_LATENCY_BLOCKS: prometheus::Histogram = {
         // High resolution for 1-9 blocks
         let mut buckets = linear_buckets(1.0, 1.0, 9).unwrap();
         // 10, 15, 22.5, 33.75, 50, ..., 256, 384
@@ -216,7 +216,7 @@ lazy_static! {
         buckets.extend(exponential_buckets);
 
         prometheus::register_histogram!(
-            "mpc_number_of_blocks_between_sign_request_and_response",
+            "mpc_signature_request_response_latency_blocks",
             "The number of blocks between when a signature request is seen and when the corresponding response is seen.",
             buckets).
             unwrap()


### PR DESCRIPTION
Part of #255 

This PR adds a new histogram metric `mpc_signature_request_response_latency_blocks` to track the number of blocks between a signature request is observed and its corresponding response is observed on the smart contract.

