### PR TITLE
Add web endpoint /debug/contract

### DIFF
--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -23,7 +23,7 @@ serde_yaml = "0.9.34"
 tokio = { version = "1.43.0", features = ["full"] }
 
 legacy-mpc-contract = { package = "mpc-contract", git = "https://github.com/Near-One/mpc/", rev = "1d4954dff28e8eb988fb7762eff414a602a2b124" }
-mpc-contract = { path = "../libs/chain-signatures/contract", features = ["test-utils"]}
+mpc-contract = { path = "../libs/chain-signatures/contract", features = ["test-utils", "dev-utils"]}
 
 
 [workspace]

--- a/devnet/src/mpc.rs
+++ b/devnet/src/mpc.rs
@@ -20,6 +20,7 @@ use mpc_contract::primitives::key_state::EpochId;
 use mpc_contract::primitives::participants::{ParticipantInfo, Participants};
 use mpc_contract::primitives::thresholds::{Threshold, ThresholdParameters};
 use mpc_contract::state::ProtocolContractState;
+use mpc_contract::utils::protocol_state_to_string;
 use near_crypto::SecretKey;
 use near_sdk::{borsh, AccountId};
 use serde::Serialize;
@@ -952,132 +953,12 @@ impl MpcDescribeCmd {
         if let Some(contract) = &mpc_setup.contract {
             println!("MPC contract deployed at: {}", contract);
             let contract_state = read_contract_state_v2(&setup.accounts, contract).await;
-            match contract_state {
-                ProtocolContractState::NotInitialized => {
-                    println!("Contract is not initialized");
-                }
-                ProtocolContractState::Initializing(state) => {
-                    println!("Contract is in Initializing state (key generation)");
-                    println!("  Epoch: {}", state.generating_key.epoch_id());
-                    println!("  Domains:");
-                    for (i, domain) in state.domains.domains().iter().enumerate() {
-                        print!("    Domain {}: {:?}, ", domain.id, domain.scheme);
-                        #[allow(clippy::comparison_chain)]
-                        if i < state.generated_keys.len() {
-                            println!(
-                                "key generated (attempt ID {})",
-                                state.generated_keys[i].attempt
-                            );
-                        } else if i == state.generated_keys.len() {
-                            print!("generating key: ");
-                            if state.generating_key.is_active() {
-                                println!(
-                                    "active; current attempt ID: {}",
-                                    state
-                                        .generating_key
-                                        .current_key_event_id()
-                                        .unwrap()
-                                        .attempt_id
-                                );
-                            } else {
-                                println!(
-                                    "not active; next attempt ID: {}",
-                                    state.generating_key.next_attempt_id()
-                                );
-                            }
-                        } else {
-                            println!("queued for generation");
-                        }
-                    }
-                    println!("  Parameters:");
-                    Self::print_parameters(state.generating_key.proposed_parameters());
-                    println!("  Warning: this tool does not calculate automatic timeouts for key generation attempts");
-                }
-                ProtocolContractState::Running(state) => {
-                    println!("Contract is in Running state");
-                    println!("  Epoch: {}", state.keyset.epoch_id);
-                    println!("  Keyset:");
-                    for (domain, key) in state
-                        .domains
-                        .domains()
-                        .iter()
-                        .zip(state.keyset.domains.iter())
-                    {
-                        println!(
-                            "    Domain {}: {:?}, key from attempt {}",
-                            domain.id, domain.scheme, key.attempt
-                        );
-                    }
-                    println!("  Parameters:");
-                    Self::print_parameters(&state.parameters);
-                }
-                ProtocolContractState::Resharing(state) => {
-                    println!("Contract is in Resharing state");
-                    println!(
-                        "  Epoch transition: original {} --> prospective {}",
-                        state.previous_running_state.keyset.epoch_id,
-                        state.prospective_epoch_id()
-                    );
-                    println!("  Domains:");
-                    for (i, domain) in state
-                        .previous_running_state
-                        .domains
-                        .domains()
-                        .iter()
-                        .enumerate()
-                    {
-                        print!(
-                            "    Domain {}: {:?}, original key from attempt {}, ",
-                            domain.id,
-                            domain.scheme,
-                            state.previous_running_state.keyset.domains[i].attempt
-                        );
-
-                        #[allow(clippy::comparison_chain)]
-                        if i < state.reshared_keys.len() {
-                            println!("reshared (attempt ID {})", state.reshared_keys[i].attempt);
-                        } else if i == state.reshared_keys.len() {
-                            print!("resharing key: ");
-                            if state.resharing_key.is_active() {
-                                println!(
-                                    "active; current attempt ID: {}",
-                                    state
-                                        .resharing_key
-                                        .current_key_event_id()
-                                        .unwrap()
-                                        .attempt_id
-                                );
-                            } else {
-                                println!(
-                                    "not active; next attempt ID: {}",
-                                    state.resharing_key.next_attempt_id()
-                                );
-                            }
-                        } else {
-                            println!("queued for resharing");
-                        }
-                    }
-                    println!("  Previous Parameters:");
-                    Self::print_parameters(&state.previous_running_state.parameters);
-                    println!("  Proposed Parameters:");
-                    Self::print_parameters(state.resharing_key.proposed_parameters());
-
-                    println!("  Warning: this tool does not calculate automatic timeouts for resharing attempts");
-                }
-            }
+            print!("{}", protocol_state_to_string(&contract_state));
         } else {
             println!("MPC contract is not deployed");
         }
         println!();
 
         self.describe_terraform(name, &config).await;
-    }
-
-    fn print_parameters(parameters: &ThresholdParameters) {
-        println!("    Participants:");
-        for (account_id, id, info) in parameters.participants().participants() {
-            println!("      ID {}: {} ({})", id, account_id, info.url);
-        }
-        println!("    Threshold: {}", parameters.threshold().value());
     }
 }

--- a/libs/chain-signatures/contract/Cargo.toml
+++ b/libs/chain-signatures/contract/Cargo.toml
@@ -66,3 +66,4 @@ rstest = "0.25.0"
 
 [features]
 test-utils = ["rand"]
+dev-utils = []

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -6,6 +6,8 @@ pub mod primitives;
 pub mod state;
 pub mod storage_keys;
 pub mod update;
+#[cfg(feature = "dev-utils")]
+pub mod utils;
 
 use crate::errors::Error;
 use crate::update::{ProposeUpdateArgs, ProposedUpdates, Update, UpdateId};

--- a/libs/chain-signatures/contract/src/primitives/votes.rs
+++ b/libs/chain-signatures/contract/src/primitives/votes.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 /// Each current participant can maintain one vote.
 #[near(serializers=[borsh, json])]
 #[derive(Debug, Default, PartialEq)]
+#[cfg_attr(feature = "dev-utils", derive(Clone))]
 pub struct ThresholdParametersVotes {
     proposal_by_account: BTreeMap<AuthenticatedParticipantId, ThresholdParameters>,
 }

--- a/libs/chain-signatures/contract/src/state/initializing.rs
+++ b/libs/chain-signatures/contract/src/state/initializing.rs
@@ -26,6 +26,7 @@ use std::collections::BTreeSet;
 /// and we wish to perform a resharing before adding domains again.
 #[near(serializers=[borsh, json])]
 #[derive(Debug)]
+#[cfg_attr(feature = "dev-utils", derive(Clone))]
 pub struct InitializingContractState {
     /// All domains, including the already existing ones and the ones we're generating a new key for
     pub domains: DomainRegistry,

--- a/libs/chain-signatures/contract/src/state/key_event.rs
+++ b/libs/chain-signatures/contract/src/state/key_event.rs
@@ -184,7 +184,7 @@ impl KeyEvent {
     }
 
     /// Returns whether an attempt is active ()and not timed out).
-    #[cfg(any(test, feature = "test-utils"))]
+    #[cfg(any(test, feature = "test-utils", feature = "dev-utils"))]
     pub fn is_active(&self) -> bool {
         self.current_key_event_id().is_some()
     }

--- a/libs/chain-signatures/contract/src/state/mod.rs
+++ b/libs/chain-signatures/contract/src/state/mod.rs
@@ -17,6 +17,7 @@ use running::RunningContractState;
 
 #[near(serializers=[borsh, json])]
 #[derive(Debug)]
+#[cfg_attr(feature = "dev-utils", derive(Clone))]
 pub enum ProtocolContractState {
     NotInitialized,
     Initializing(InitializingContractState),

--- a/libs/chain-signatures/contract/src/state/resharing.rs
+++ b/libs/chain-signatures/contract/src/state/resharing.rs
@@ -21,6 +21,7 @@ use near_sdk::near;
 ///  - We use the previous running state's DomainRegistry.
 #[near(serializers=[borsh, json])]
 #[derive(Debug)]
+#[cfg_attr(feature = "dev-utils", derive(Clone))]
 pub struct ResharingContractState {
     pub previous_running_state: RunningContractState,
     pub reshared_keys: Vec<KeyForDomain>,

--- a/libs/chain-signatures/contract/src/state/running.rs
+++ b/libs/chain-signatures/contract/src/state/running.rs
@@ -23,6 +23,7 @@ use std::collections::BTreeSet;
 ///    threshold if desired.
 #[near(serializers=[borsh, json])]
 #[derive(Debug)]
+#[cfg_attr(feature = "dev-utils", derive(Clone))]
 pub struct RunningContractState {
     /// The domains for which we have a key ready for signature processing.
     pub domains: DomainRegistry,

--- a/libs/chain-signatures/contract/src/utils.rs
+++ b/libs/chain-signatures/contract/src/utils.rs
@@ -1,0 +1,135 @@
+use crate::{primitives::thresholds::ThresholdParameters, state::ProtocolContractState};
+
+fn params_to_string(output: &mut String, parameters: &ThresholdParameters) {
+    output.push_str(&format!("    Participants:\n"));
+    for (account_id, id, info) in parameters.participants().participants() {
+        output.push_str(&format!("      ID {}: {} ({})\n", id, account_id, info.url));
+    }
+    output.push_str(&format!(
+        "    Threshold: {}\n",
+        parameters.threshold().value()
+    ));
+}
+
+pub fn protocol_state_to_string(contract_state: &ProtocolContractState) -> String {
+    let mut output = String::new();
+    match contract_state {
+        ProtocolContractState::NotInitialized => {
+            output.push_str(&format!("Contract is not initialized\n"));
+        }
+        ProtocolContractState::Initializing(state) => {
+            output.push_str(&format!(
+                "Contract is in Initializing state (key generation)"
+            ));
+            output.push_str(&format!("  Epoch: {}\n", state.generating_key.epoch_id()));
+            output.push_str(&format!("  Domains:\n"));
+            for (i, domain) in state.domains.domains().iter().enumerate() {
+                output.push_str(&format!("    Domain {}: {:?}, ", domain.id, domain.scheme));
+                #[allow(clippy::comparison_chain)]
+                if i < state.generated_keys.len() {
+                    output.push_str(&format!(
+                        "key generated (attempt ID {})\n",
+                        state.generated_keys[i].attempt
+                    ));
+                } else if i == state.generated_keys.len() {
+                    output.push_str(&format!("generating key: "));
+                    if state.generating_key.is_active() {
+                        output.push_str(&format!(
+                            "active; current attempt ID: {}\n",
+                            state
+                                .generating_key
+                                .current_key_event_id()
+                                .unwrap()
+                                .attempt_id
+                        ));
+                    } else {
+                        output.push_str(&format!(
+                            "not active; next attempt ID: {}\n",
+                            state.generating_key.next_attempt_id()
+                        ));
+                    }
+                } else {
+                    output.push_str(&format!("queued for generation\n"));
+                }
+            }
+            output.push_str(&format!("  Parameters:\n"));
+            params_to_string(&mut output, state.generating_key.proposed_parameters());
+            output.push_str(&format!("  Warning: this tool does not calculate automatic timeouts for key generation attempts\n"));
+        }
+        ProtocolContractState::Running(state) => {
+            output.push_str(&format!("Contract is in Running state\n"));
+            output.push_str(&format!("  Epoch: {}\n", state.keyset.epoch_id));
+            output.push_str(&format!("  Keyset:\n"));
+            for (domain, key) in state
+                .domains
+                .domains()
+                .iter()
+                .zip(state.keyset.domains.iter())
+            {
+                output.push_str(&format!(
+                    "    Domain {}: {:?}, key from attempt {}\n",
+                    domain.id, domain.scheme, key.attempt
+                ));
+            }
+            output.push_str(&format!("  Parameters:\n"));
+            params_to_string(&mut output, &state.parameters);
+        }
+        ProtocolContractState::Resharing(state) => {
+            output.push_str(&format!("Contract is in Resharing state\n"));
+            output.push_str(&format!(
+                "  Epoch transition: original {} --> prospective {}\n",
+                state.previous_running_state.keyset.epoch_id,
+                state.prospective_epoch_id()
+            ));
+            output.push_str(&format!("  Domains:\n"));
+            for (i, domain) in state
+                .previous_running_state
+                .domains
+                .domains()
+                .iter()
+                .enumerate()
+            {
+                output.push_str(&format!(
+                    "    Domain {}: {:?}, original key from attempt {}, ",
+                    domain.id,
+                    domain.scheme,
+                    state.previous_running_state.keyset.domains[i].attempt
+                ));
+
+                #[allow(clippy::comparison_chain)]
+                if i < state.reshared_keys.len() {
+                    output.push_str(&format!(
+                        "reshared (attempt ID {})\n",
+                        state.reshared_keys[i].attempt
+                    ));
+                } else if i == state.reshared_keys.len() {
+                    output.push_str(&format!("resharing key: "));
+                    if state.resharing_key.is_active() {
+                        output.push_str(&format!(
+                            "active; current attempt ID: {}\n",
+                            state
+                                .resharing_key
+                                .current_key_event_id()
+                                .unwrap()
+                                .attempt_id
+                        ));
+                    } else {
+                        output.push_str(&format!(
+                            "not active; next attempt ID: {}\n",
+                            state.resharing_key.next_attempt_id()
+                        ));
+                    }
+                } else {
+                    output.push_str(&format!("queued for resharing\n"));
+                }
+            }
+            output.push_str(&format!("  Previous Parameters:\n"));
+            params_to_string(&mut output, &state.previous_running_state.parameters);
+            output.push_str(&format!("  Proposed Parameters:\n"));
+            params_to_string(&mut output, state.resharing_key.proposed_parameters());
+
+            output.push_str(&format!("  Warning: this tool does not calculate automatic timeouts for resharing attempts\n"));
+        }
+    }
+    output
+}

--- a/libs/chain-signatures/contract/src/utils.rs
+++ b/libs/chain-signatures/contract/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{primitives::thresholds::ThresholdParameters, state::ProtocolContractState};
 
 fn params_to_string(output: &mut String, parameters: &ThresholdParameters) {
-    output.push_str(&format!("    Participants:\n"));
+    output.push_str("    Participants:\n");
     for (account_id, id, info) in parameters.participants().participants() {
         output.push_str(&format!("      ID {}: {} ({})\n", id, account_id, info.url));
     }
@@ -15,14 +15,12 @@ pub fn protocol_state_to_string(contract_state: &ProtocolContractState) -> Strin
     let mut output = String::new();
     match contract_state {
         ProtocolContractState::NotInitialized => {
-            output.push_str(&format!("Contract is not initialized\n"));
+            output.push_str("Contract is not initialized\n");
         }
         ProtocolContractState::Initializing(state) => {
-            output.push_str(&format!(
-                "Contract is in Initializing state (key generation)"
-            ));
+            output.push_str("Contract is in Initializing state (key generation)");
             output.push_str(&format!("  Epoch: {}\n", state.generating_key.epoch_id()));
-            output.push_str(&format!("  Domains:\n"));
+            output.push_str("  Domains:\n");
             for (i, domain) in state.domains.domains().iter().enumerate() {
                 output.push_str(&format!("    Domain {}: {:?}, ", domain.id, domain.scheme));
                 #[allow(clippy::comparison_chain)]
@@ -32,7 +30,7 @@ pub fn protocol_state_to_string(contract_state: &ProtocolContractState) -> Strin
                         state.generated_keys[i].attempt
                     ));
                 } else if i == state.generated_keys.len() {
-                    output.push_str(&format!("generating key: "));
+                    output.push_str("generating key: ");
                     if state.generating_key.is_active() {
                         output.push_str(&format!(
                             "active; current attempt ID: {}\n",
@@ -49,17 +47,17 @@ pub fn protocol_state_to_string(contract_state: &ProtocolContractState) -> Strin
                         ));
                     }
                 } else {
-                    output.push_str(&format!("queued for generation\n"));
+                    output.push_str("queued for generation\n");
                 }
             }
-            output.push_str(&format!("  Parameters:\n"));
+            output.push_str("  Parameters:\n");
             params_to_string(&mut output, state.generating_key.proposed_parameters());
-            output.push_str(&format!("  Warning: this tool does not calculate automatic timeouts for key generation attempts\n"));
+            output.push_str("  Warning: this tool does not calculate automatic timeouts for key generation attempts\n");
         }
         ProtocolContractState::Running(state) => {
-            output.push_str(&format!("Contract is in Running state\n"));
+            output.push_str("Contract is in Running state\n");
             output.push_str(&format!("  Epoch: {}\n", state.keyset.epoch_id));
-            output.push_str(&format!("  Keyset:\n"));
+            output.push_str("  Keyset:\n");
             for (domain, key) in state
                 .domains
                 .domains()
@@ -71,17 +69,17 @@ pub fn protocol_state_to_string(contract_state: &ProtocolContractState) -> Strin
                     domain.id, domain.scheme, key.attempt
                 ));
             }
-            output.push_str(&format!("  Parameters:\n"));
+            output.push_str("  Parameters:\n");
             params_to_string(&mut output, &state.parameters);
         }
         ProtocolContractState::Resharing(state) => {
-            output.push_str(&format!("Contract is in Resharing state\n"));
+            output.push_str("Contract is in Resharing state\n");
             output.push_str(&format!(
                 "  Epoch transition: original {} --> prospective {}\n",
                 state.previous_running_state.keyset.epoch_id,
                 state.prospective_epoch_id()
             ));
-            output.push_str(&format!("  Domains:\n"));
+            output.push_str("  Domains:\n");
             for (i, domain) in state
                 .previous_running_state
                 .domains
@@ -103,7 +101,7 @@ pub fn protocol_state_to_string(contract_state: &ProtocolContractState) -> Strin
                         state.reshared_keys[i].attempt
                     ));
                 } else if i == state.reshared_keys.len() {
-                    output.push_str(&format!("resharing key: "));
+                    output.push_str("resharing key: ");
                     if state.resharing_key.is_active() {
                         output.push_str(&format!(
                             "active; current attempt ID: {}\n",
@@ -120,15 +118,15 @@ pub fn protocol_state_to_string(contract_state: &ProtocolContractState) -> Strin
                         ));
                     }
                 } else {
-                    output.push_str(&format!("queued for resharing\n"));
+                    output.push_str("queued for resharing\n");
                 }
             }
-            output.push_str(&format!("  Previous Parameters:\n"));
+            output.push_str("  Previous Parameters:\n");
             params_to_string(&mut output, &state.previous_running_state.parameters);
-            output.push_str(&format!("  Proposed Parameters:\n"));
+            output.push_str("  Proposed Parameters:\n");
             params_to_string(&mut output, state.resharing_key.proposed_parameters());
 
-            output.push_str(&format!("  Warning: this tool does not calculate automatic timeouts for resharing attempts\n"));
+            output.push_str("  Warning: this tool does not calculate automatic timeouts for resharing attempts\n");
         }
     }
     output

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -60,7 +60,7 @@ near-o11y = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
 near-time = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
 # todo: update once 1.1.0 is pulbished (though the api did not change)
 legacy-mpc-contract = { package = "mpc-contract", git = "https://github.com/Near-One/mpc/", rev = "1d4954dff28e8eb988fb7762eff414a602a2b124" }
-mpc-contract = { path = "../libs/chain-signatures/contract/" }
+mpc-contract = { path = "../libs/chain-signatures/contract/" , features = ["dev-utils"]}
 # Pinned to resolve compilation errors with conflicting implementations of PartialOrd trait
 # See error E0283 with multiple impls satisfying `u128: std::cmp::PartialOrd<_>`
 deranged = "=0.4.0"

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -2,6 +2,7 @@ use cait_sith::ecdsa::presign::PresignOutput;
 use cait_sith::ecdsa::triples::TripleGenerationOutput;
 use cait_sith::protocol::{run_protocol, Participant, Protocol};
 use k256::{AffinePoint, Scalar, Secp256k1};
+use mpc_contract::state::ProtocolContractState;
 use std::collections::HashMap;
 
 use crate::config::{
@@ -206,10 +207,13 @@ impl OneNodeTestConfig {
             let root_future = async move {
                 let root_task_handle = tracking::current_task();
                 let (signature_debug_request_sender, _) = tokio::sync::broadcast::channel(10);
+                let (_, web_contract_receiver) =
+                    tokio::sync::watch::channel(ProtocolContractState::NotInitialized);
                 let web_server = start_web_server(
                     root_task_handle,
                     signature_debug_request_sender.clone(),
                     config.web_ui.clone(),
+                    web_contract_receiver.clone(),
                 )
                 .await?;
                 let _web_server = tracking::spawn_checked("web server", web_server);

--- a/pytest/tests/test_web_endpoints.py
+++ b/pytest/tests/test_web_endpoints.py
@@ -37,3 +37,6 @@ def test_web_endpoints():
         response = requests.get(f'http://localhost:{port}/debug/signatures')
         assert 'Recent Signatures:' in response.text, response.text
         assert 'id:' in response.text, response.text
+
+        response = requests.get(f'http://localhost:{port}/debug/contract')
+        assert 'Contract is in Running state' in response.text, response.text


### PR DESCRIPTION
This PR exposes a new web endpoint `debug/contract`, that displays the current contract view of an mpc node..

It uses the logic introduced in https://github.com/Near-One/mpc/pull/351 to stringify the current ProtocolState instance and moves this logic to the contract folder (behind a `dev-utils` feature flag).

follow-ups:
- [ ] additionally, display `ThresholdParameterVotes`, `AddDomainVotes` and proposed updates.