### PR TITLE
fix: return early in Indexer thread and `listen_blocks` if channel to MPC node is closed.

### DIFF
--- a/node/src/indexer/real.rs
+++ b/node/src/indexer/real.rs
@@ -19,7 +19,7 @@ pub fn spawn_real_indexer(
     my_near_account_id: AccountId,
     account_secret_key: SecretKey,
     protocol_state_sender: tokio::sync::watch::Sender<ProtocolContractState>,
-) -> (std::thread::JoinHandle<()>, IndexerAPI) {
+) -> (std::thread::JoinHandle<anyhow::Result<()>>, IndexerAPI) {
     let (chain_config_sender, chain_config_receiver) =
         tokio::sync::watch::channel::<ContractState>(ContractState::WaitingForSync);
     let (block_update_sender, block_update_receiver) = mpsc::unbounded_channel();
@@ -75,8 +75,8 @@ pub fn spawn_real_indexer(
                 indexer_config.mpc_contract_id,
                 block_update_sender,
             )
-            .await;
-        });
+            .await
+        })
     });
     (
         thread,


### PR DESCRIPTION
The indexer thread should terminate if the channel it sends block updates to is closed, as this is an unrecoverable event.