### PR TITLE
chore: remove spawn_blocking call wrapping the indexer thread

### DIFF
--- a/node/src/indexer/real.rs
+++ b/node/src/indexer/real.rs
@@ -19,7 +19,7 @@ pub fn spawn_real_indexer(
     my_near_account_id: AccountId,
     account_secret_key: SecretKey,
     protocol_state_sender: tokio::sync::watch::Sender<ProtocolContractState>,
-) -> (std::thread::JoinHandle<()>, IndexerAPI) {
+) -> (std::thread::JoinHandle<anyhow::Result<()>>, IndexerAPI) {
     let (chain_config_sender, chain_config_receiver) =
         tokio::sync::watch::channel::<ContractState>(ContractState::WaitingForSync);
     let (block_update_sender, block_update_receiver) = mpsc::unbounded_channel();
@@ -75,8 +75,8 @@ pub fn spawn_real_indexer(
                 indexer_config.mpc_contract_id,
                 block_update_sender,
             )
-            .await;
-        });
+            .await
+        })
     });
     (
         thread,

--- a/node/src/indexer/real.rs
+++ b/node/src/indexer/real.rs
@@ -29,7 +29,8 @@ pub fn spawn_real_indexer(
     let (chain_txn_sender, chain_txn_receiver) = mpsc::channel(10000);
 
     // TODO(#156): replace actix with tokio
-    actix::System::new().block_on(async {
+    std::thread::spawn(move || {
+        actix::System::new().block_on(async {
             let indexer =
                 near_indexer::Indexer::new(indexer_config.to_near_indexer_config(home_dir.clone()))
                     .expect("Failed to initialize the Indexer");
@@ -83,6 +84,7 @@ pub fn spawn_real_indexer(
                 tracing::error!("Indexer thread could not send result back to main driver.")
             };
         });
+    });
 
     IndexerAPI {
         contract_state_receiver: chain_config_receiver,


### PR DESCRIPTION
We have a `spawn_blocking` that wraps the join_handle in `spawn_real_indexer`. This is presumably done to await on the `std::thread::JoinHandle` returned from the spawned indexer.

The `spawn_blocking` call lead to the issue we saw the other day with the binary not exiting, because the runtime is unable to drop this task since it never terminates. We can remove this `spawn_blocking call`, and use a [oneshot channel](https://docs.rs/tokio/latest/tokio/sync/oneshot/fn.channel.html) instead that the indexer thread can respond on if it exits.

In general  oneshot channels are a good practice to use when communicating from a synchronous threads to an async task.