### PR TITLE
Requires full threshold votes for keygen and reshare

### DIFF
--- a/libs/chain-signatures/contract/src/config/mod.rs
+++ b/libs/chain-signatures/contract/src/config/mod.rs
@@ -28,7 +28,6 @@ pub struct Config {
 ///
 /// use mpc_contract::config::Config;
 /// let config : Config = Some(init_config).into();
-/// assert_eq!(config.request_timeout_blocks, 1000);
 /// use mpc_contract::config::consts::DEFAULT_KEY_EVENT_TIMEOUT_BLOCKS;
 /// assert_eq!(config.key_event_timeout_blocks, DEFAULT_KEY_EVENT_TIMEOUT_BLOCKS);
 /// ```

--- a/libs/chain-signatures/contract/src/state/initializing.rs
+++ b/libs/chain-signatures/contract/src/state/initializing.rs
@@ -176,10 +176,7 @@ mod tests {
         let domains_to_add = gen_domains_to_add(&running.domains, num_domains - num_generated);
 
         let mut initializing_state = None;
-        let voting_participants = running.parameters.participants().participants()
-            [0..running.parameters.threshold().value() as usize]
-            .to_vec();
-        for (account, _, _) in voting_participants {
+        for (account, _, _) in running.parameters.participants().participants().clone() {
             env.set_signer(&account);
             assert!(initializing_state.is_none());
             initializing_state = running.vote_add_domains(domains_to_add.clone()).unwrap();

--- a/libs/chain-signatures/contract/src/state/resharing.rs
+++ b/libs/chain-signatures/contract/src/state/resharing.rs
@@ -46,9 +46,9 @@ impl ResharingContractState {
         self.resharing_key.epoch_id()
     }
 
-    /// Casts a vote for a re-proposal. Requires the signer to be an original participant from the
-    /// previous running state. If this exceeds the threshold (from the previous running state),
-    /// returns a new ResharingContractState that we should transition into.
+    /// Casts a vote for a re-proposal. Requires the signer to be a participant of the
+    /// prospective epoch.
+    /// Returns a new ResharingContractState if all proposed participants voted for it.
     pub fn vote_new_parameters(
         &mut self,
         prospective_epoch_id: EpochId,
@@ -171,11 +171,8 @@ mod tests {
         let mut running = gen_running_state(num_domains);
         let proposal = gen_valid_params_proposal(&running.parameters);
         let mut resharing_state = None;
-        let voting_participants = running.parameters.participants().participants()
-            [0..running.parameters.threshold().value() as usize]
-            .to_vec();
-        for (account, _, _) in voting_participants {
-            env.set_signer(&account);
+        for (account, _, _) in proposal.participants().participants() {
+            env.set_signer(account);
             assert!(resharing_state.is_none());
             resharing_state = running
                 .vote_new_parameters(running.keyset.epoch_id.next(), &proposal)
@@ -359,7 +356,6 @@ mod tests {
             .parameters
             .participants()
             .clone();
-        let old_threshold = state.previous_running_state.parameters.threshold().value() as usize;
         {
             let new_participants = state
                 .resharing_key
@@ -383,7 +379,7 @@ mod tests {
         // should be rejected, since all re-proposals must be valid against the original.
         let mut new_participants_1 = old_participants.clone();
         let new_threshold = Threshold::new(old_participants.len() as u64);
-        new_participants_1.add_random_participants_till_n(old_participants.len() * 3 / 2);
+        new_participants_1.add_random_participants_till_n((old_participants.len() * 3).div_ceil(2));
         let new_participants_2 = new_participants_1
             .subset(new_participants_1.len() - old_participants.len()..new_participants_1.len());
         let new_params_1 =
@@ -416,7 +412,7 @@ mod tests {
 
         // Repropose with new_params_1.
         let mut new_state = None;
-        for (account, _, _) in &old_participants.participants()[0..old_threshold] {
+        for (account, _, _) in new_params_1.participants().participants() {
             env.set_signer(account);
             assert!(new_state.is_none());
             new_state = state

--- a/libs/chain-signatures/contract/tests/common.rs
+++ b/libs/chain-signatures/contract/tests/common.rs
@@ -66,9 +66,9 @@ pub fn candidates(names: Option<Vec<AccountId>>) -> Participants {
     participants
 }
 /// Create `amount` accounts and return them along with the candidate info.
-pub async fn accounts(worker: &Worker<Sandbox>) -> (Vec<Account>, Participants) {
-    let mut accounts = Vec::with_capacity(PARTICIPANT_LEN);
-    for _ in 0..PARTICIPANT_LEN {
+pub async fn gen_accounts(worker: &Worker<Sandbox>, amount: usize) -> (Vec<Account>, Participants) {
+    let mut accounts = Vec::with_capacity(amount);
+    for _ in 0..amount {
         log!("attempting to create account");
         let account = worker.dev_create_account().await.unwrap();
         log!("created account");
@@ -89,7 +89,7 @@ pub async fn init_with_candidates(
     pks: Vec<near_crypto::PublicKey>,
 ) -> (Worker<Sandbox>, Contract, Vec<Account>) {
     let (worker, contract) = init().await;
-    let (accounts, participants) = accounts(&worker).await;
+    let (accounts, participants) = gen_accounts(&worker, PARTICIPANT_LEN).await;
     let threshold = ((participants.len() as f64) * 0.6).ceil() as u64;
     let threshold = Threshold::new(threshold);
     let threshold_parameters = ThresholdParameters::new(participants, threshold).unwrap();

--- a/pytest/common_lib/shared.py
+++ b/pytest/common_lib/shared.py
@@ -1,5 +1,4 @@
 import base64
-import random
 import base58
 import os
 import sys
@@ -414,7 +413,7 @@ class MpcCluster:
         args = {
             'domains': domains_to_add,
         }
-        for node in random.sample(self.get_voters(), k=state.threshold()):
+        for node in self.get_voters():
             print(f"{node.print()} voting to add domain(s)")
             tx = node.sign_tx(self.mpc_contract_account(),
                               'vote_add_domains',
@@ -440,8 +439,7 @@ class MpcCluster:
         }
         state = self.contract_state()
         assert state.is_state('Running'), "Require running state"
-        old_threshold = state.threshold()
-        for node in random.sample(self.get_voters(), k=old_threshold):
+        for node in new_participants:
             tx = node.sign_tx(self.mpc_contract_account(),
                               'vote_new_parameters', args)
             node.send_txn_and_check_success(tx)

--- a/pytest/tests/test_key_event.py
+++ b/pytest/tests/test_key_event.py
@@ -8,6 +8,7 @@ At every step we check that signatures can still be produced.
 
 import sys
 import pathlib
+import time
 import pytest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -53,12 +54,13 @@ def test_single_domain():
 
     cluster.update_participant_status()
     cluster.send_and_await_signature_requests(1)
+    mpc_nodes[0].run()
+    time.sleep(5)
     cluster.do_resharing(new_participants=mpc_nodes[0:4],
                          new_threshold=3,
                          prospective_epoch_id=3,
                          wait_for_running=False)
 
-    mpc_nodes[0].run()
     assert cluster.wait_for_state('Running'), "failed to start running"
     cluster.update_participant_status()
     cluster.send_and_await_signature_requests(1)


### PR DESCRIPTION
The contract requires:
- all current participants to vote for the new domain in order to enter keygen;
- all prospective participants of the prospective epoch to vote for the proposed parameters in order to enter reshare.

Note that the latter implicitly requires `threshold` number of votes from current participants, because the prospective participant set must have at least as many current participants.