### PR TITLE
chore: Add metrics for latency of signature request responses in seconds

### DIFF
--- a/node/src/signing/metrics.rs
+++ b/node/src/signing/metrics.rs
@@ -61,4 +61,12 @@ lazy_static! {
             unwrap()
 
     };
+
+    pub static ref SIGNATURE_REQUEST_RESPONSE_LATENCY_SECONDS: prometheus::Histogram =
+        prometheus::register_histogram!(
+            "mpc_signature_request_response_latency_seconds",
+            "The duration, in seconds, between when a signature request is seen and when the corresponding response is seen.",
+            // 2s - 3s - 4.5s .... - 115s
+            exponential_buckets(2.0, 1.5, 10).unwrap()
+            ).unwrap();
 }


### PR DESCRIPTION
We added a latency metric for sign requests in terms of number of blocks between a sign and response was seen on chain #366.

This PR adds the same metric, but measures the latency in absolute duration.
https://github.com/Near-One/mpc/pull/366#pullrequestreview-2764916681