### PR TITLE
Correctly export signature latency metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3990,6 +3990,7 @@ dependencies = [
  "serial_test",
  "sha3",
  "tempfile",
+ "time",
  "tokio",
  "tokio-rustls",
  "tokio-stream",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "1.0.132"
 serde_yaml = "0.9.34"
 sha3 = "0.10.8"
 tempfile = "=3.14.0"
+time = "0.3.41"
 tokio = { version = "1.41.0", features = ["full"] }
 tokio-util = "0.7.12"
 tokio-rustls = { version = "0.26.1", default-features = false }

--- a/node/src/signing/debug.rs
+++ b/node/src/signing/debug.rs
@@ -69,25 +69,22 @@ impl Debug for CompletedSignatureRequest {
             "  [completed] blk {:>10} -> {:<24} id: {} rx: {:<44} tries: {:<2}",
             self.indexed_block_height,
             self.completion_delay
-                .map(|(delay_blocks, delay_time)| format!(
-                    "{:>10} (+{}, {})",
-                    self.indexed_block_height + delay_blocks,
-                    delay_blocks,
-                    humantime::format_duration(
-                        round_duration_to_milliseconds(delay_time).unsigned_abs()
-                    ),
-                ))
+                .map(|(delay_blocks, delay_time)| {
+                    let duration_rounded_to_ms =
+                        near_time::Duration::milliseconds(delay_time.whole_milliseconds() as i64);
+                    format!(
+                        "{:>10} (+{}, {})",
+                        self.indexed_block_height + delay_blocks,
+                        delay_blocks,
+                        duration_rounded_to_ms,
+                    )
+                })
                 .unwrap_or("?".to_string()),
             &format!("{:?}", self.request.id)[0..6],
             format!("{:?}", self.request.receipt_id),
             self.progress.lock().unwrap().attempts,
         )
     }
-}
-
-fn round_duration_to_milliseconds(duration: near_time::Duration) -> near_time::Duration {
-    let milliseconds = duration.whole_milliseconds();
-    near_time::Duration::milliseconds(milliseconds as i64)
 }
 
 impl QueuedSignatureRequest {

--- a/node/src/signing/debug.rs
+++ b/node/src/signing/debug.rs
@@ -3,6 +3,7 @@ use super::queue::{
 };
 use crate::primitives::ParticipantId;
 use crate::sign_request::SignatureRequest;
+use near_indexer_primitives::types::{BlockHeight, NumBlocks};
 use std::collections::{BinaryHeap, HashSet};
 use std::fmt::Debug;
 use std::fmt::Write;
@@ -14,8 +15,10 @@ const NUM_COMPLETED_REQUESTS_TO_KEEP: usize = 100;
 pub(super) struct CompletedSignatureRequest {
     pub request: SignatureRequest,
     pub progress: Arc<Mutex<SignatureComputationProgress>>,
-    pub indexed_block_height: u64,
-    pub completed_block_height: Option<u64>,
+    pub indexed_block_height: BlockHeight,
+    /// The block height at which the request was responded to successfully,
+    /// as well as the delay in wall time observed from the indexer.
+    pub completion_delay: Option<(NumBlocks, near_time::Duration)>,
 }
 
 /// A buffer of completed signature requests, for exporting to /debug/signatures.
@@ -63,13 +66,16 @@ impl Debug for CompletedSignatureRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "  [completed] blk {:>10} -> {:<16} id: {} rx: {:<44} tries: {:<2}",
+            "  [completed] blk {:>10} -> {:<24} id: {} rx: {:<44} tries: {:<2}",
             self.indexed_block_height,
-            self.completed_block_height
-                .map(|h| format!(
-                    "{:>10} (+{})",
-                    h,
-                    h.saturating_sub(self.indexed_block_height)
+            self.completion_delay
+                .map(|(delay_blocks, delay_time)| format!(
+                    "{:>10} (+{}, {})",
+                    self.indexed_block_height + delay_blocks,
+                    delay_blocks,
+                    humantime::format_duration(
+                        round_duration_to_milliseconds(delay_time).unsigned_abs()
+                    ),
                 ))
                 .unwrap_or("?".to_string()),
             &format!("{:?}", self.request.id)[0..6],
@@ -77,6 +83,11 @@ impl Debug for CompletedSignatureRequest {
             self.progress.lock().unwrap().attempts,
         )
     }
+}
+
+fn round_duration_to_milliseconds(duration: near_time::Duration) -> near_time::Duration {
+    let milliseconds = duration.whole_milliseconds();
+    near_time::Duration::milliseconds(milliseconds as i64)
 }
 
 impl QueuedSignatureRequest {
@@ -96,7 +107,7 @@ impl QueuedSignatureRequest {
         }
         write!(
             &mut output,
-            "  {:>11} blk {:>10} -> {:<16} id: {} rx: {:<44} tries: {:<2}",
+            "  {:>11} blk {:>10} -> {:<24} id: {} rx: {:<44} tries: {:<2}",
             if leader_selection.last() == Some(&me) {
                 "[leader]"
             } else {
@@ -220,10 +231,13 @@ mod tests {
                 },
                 progress: Default::default(),
                 indexed_block_height: i,
-                completed_block_height: if rand::random::<bool>() {
+                completion_delay: if rand::random::<bool>() {
                     None
                 } else {
-                    Some(i + rand::random::<u64>() % 100)
+                    Some((
+                        i + rand::random::<u64>() % 100,
+                        near_time::Duration::milliseconds(100),
+                    ))
                 },
             });
         }

--- a/node/src/signing/queue.rs
+++ b/node/src/signing/queue.rs
@@ -881,7 +881,7 @@ mod tests {
 
         let debug = format!("{:?}", pending_requests);
         assert!(
-            debug.contains("blk        100 ->        101 (+1, 2s 432ms)"),
+            debug.contains("blk        100 ->        101 (+1, 2s432ms)"),
             "{}",
             debug
         );

--- a/node/src/signing/queue.rs
+++ b/node/src/signing/queue.rs
@@ -12,7 +12,7 @@ use sha3::Digest;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex, Weak};
-use std::time::Instant;
+use time::ext::InstantExt as _;
 
 /// The minimum time that must elapse before we'll consider each signature for another attempt.
 pub const CHECK_EACH_SIGNATURE_REQUEST_INTERVAL: Duration = Duration::seconds(1);
@@ -74,6 +74,7 @@ pub struct PendingSignatureRequests {
 struct BufferedBlockData {
     signature_requests: Vec<SignatureId>,
     completed_requests: Vec<SignatureId>,
+    timestamp_received: near_time::Instant,
 }
 
 fn ellipsified_shortened_hash_list(hashes: &[CryptoHash]) -> String {
@@ -150,8 +151,8 @@ pub(super) struct QueuedSignatureRequest {
     /// completed.
     pub active_attempt: Weak<SignatureGenerationAttempt>,
 
-    /// The [`Instant`] the signature was indexed.
-    pub indexing_instant: Instant,
+    /// The time that the signature was indexed.
+    pub time_indexed: near_time::Instant,
 }
 
 /// Struct given to the signature generation code.
@@ -183,7 +184,7 @@ impl QueuedSignatureRequest {
         block_hash: CryptoHash,
         block_height: u64,
         all_participants: &[ParticipantId],
-        indexing_instant: Instant,
+        time_indexed: near_time::Instant,
     ) -> Self {
         let leader_selection_order = Self::leader_selection_order(all_participants, request.id);
         tracing::debug!(target: "signing", "Leader selection order for request {:?} from block {}: {:?}", request.id, block_height, leader_selection_order);
@@ -196,7 +197,7 @@ impl QueuedSignatureRequest {
             computation_progress: Arc::new(Mutex::new(SignatureComputationProgress::default())),
             next_check_due: clock.now(),
             active_attempt: Weak::new(),
-            indexing_instant,
+            time_indexed,
         }
     }
 
@@ -271,6 +272,7 @@ impl PendingSignatureRequests {
             BufferedBlockData {
                 signature_requests: requests.iter().map(|r| r.id).collect(),
                 completed_requests,
+                timestamp_received: self.clock.now(),
             },
         ) {
             Ok(add_result) => add_result,
@@ -282,7 +284,7 @@ impl PendingSignatureRequests {
         };
 
         metrics::MPC_PENDING_SIGNATURES_QUEUE_BLOCKS_INDEXED.inc();
-        for (_, buffered_block_data) in add_result.new_final_blocks {
+        for (final_block_height, buffered_block_data) in add_result.new_final_blocks {
             metrics::MPC_PENDING_SIGNATURES_QUEUE_FINALIZED_BLOCKS_INDEXED.inc();
             metrics::MPC_PENDING_SIGNATURES_QUEUE_RESPONSES_INDEXED
                 .inc_by(buffered_block_data.completed_requests.len() as u64);
@@ -292,19 +294,24 @@ impl PendingSignatureRequests {
                 if let Some(request) = self.requests.remove(request_id) {
                     metrics::MPC_PENDING_SIGNATURES_QUEUE_MATCHING_RESPONSES_INDEXED.inc();
 
-                    let response_latency_blocks = block.height - request.block_height;
-                    let response_latency_duration = Instant::now() - request.indexing_instant;
+                    let response_latency_blocks = final_block_height - request.block_height;
+                    let response_latency_duration = buffered_block_data
+                        .timestamp_received
+                        .signed_duration_since(request.time_indexed);
                     metrics::SIGNATURE_REQUEST_RESPONSE_LATENCY_BLOCKS
                         .observe(response_latency_blocks as f64);
                     metrics::SIGNATURE_REQUEST_RESPONSE_LATENCY_SECONDS
-                        .observe(response_latency_duration.as_secs_f64());
+                        .observe(response_latency_duration.as_seconds_f64());
 
                     self.recently_completed_requests.add_completed_request(
                         CompletedSignatureRequest {
                             indexed_block_height: request.block_height,
                             request: request.request,
                             progress: request.computation_progress,
-                            completed_block_height: Some(block.height),
+                            completion_delay: Some((
+                                response_latency_blocks,
+                                response_latency_duration,
+                            )),
                         },
                     );
                 }
@@ -320,7 +327,7 @@ impl PendingSignatureRequests {
                     block.hash,
                     block.height,
                     &self.all_participants,
-                    Instant::now(),
+                    self.clock.now(),
                 ));
         }
     }
@@ -434,7 +441,7 @@ impl PendingSignatureRequests {
                         indexed_block_height: request.block_height,
                         request: request.request,
                         progress: request.computation_progress,
-                        completed_block_height: None,
+                        completion_delay: None,
                     });
             }
         }
@@ -834,5 +841,49 @@ mod tests {
         let to_attempt3 = pending_requests.get_signatures_to_attempt();
         assert_eq!(to_attempt3.len(), 1);
         assert_eq!(to_attempt3[0].request.id, req2.id);
+    }
+
+    #[test]
+    fn test_request_latency_debug() {
+        init_logging();
+        let clock = FakeClock::default();
+        let participants = TestGenerators::new_contiguous_participant_ids(4, 3).participant_ids();
+        let my_participant_id = participants[1];
+        let network_api = Arc::new(TestNetworkAPI::new(&participants));
+
+        let mut pending_requests = PendingSignatureRequests::new(
+            clock.clock(),
+            participants.clone(),
+            my_participant_id,
+            network_api.clone(),
+        );
+
+        for participant in &participants {
+            network_api.set_height(*participant, 100);
+        }
+
+        let t = TestBlockMaker::new();
+
+        clock.advance(near_time::Duration::seconds(1));
+        let req1 = test_sign_request(&participants, &[0]);
+        let b1 = t.block(100);
+        pending_requests.notify_new_block(vec![req1.clone()], vec![], &b1.to_block_view());
+        clock.advance(near_time::Duration::microseconds(2432123));
+        let b2 = b1.child(101);
+        pending_requests.notify_new_block(vec![], vec![req1.id], &b2.to_block_view());
+        clock.advance(near_time::Duration::seconds(1));
+        let b3 = b2.child(102);
+        pending_requests.notify_new_block(vec![], vec![], &b3.to_block_view());
+        clock.advance(near_time::Duration::seconds(1));
+        let b4 = b3.child(103);
+        pending_requests.notify_new_block(vec![], vec![], &b4.to_block_view());
+        clock.advance(near_time::Duration::seconds(1));
+
+        let debug = format!("{:?}", pending_requests);
+        assert!(
+            debug.contains("blk        100 ->        101 (+1, 2s 432ms)"),
+            "{}",
+            debug
+        );
     }
 }


### PR DESCRIPTION
Followup to #366 and #373, the block height as well as indexed time used was incorrect - we should use the block that contains the signature response, which was being held until it becomes final, instead of the block that triggers the finalization of such a block.

Fixing this required some slight modification to the data structures.

Also, use the clock instead of `Instant::now()` for getting instants. Also add a test that the metrics are correctly computed.