### PR TITLE
[Fix] Adjust gas attachment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3921,7 +3921,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "2.1.0-rc.1"
+version = "2.1.1-rc.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3968,7 +3968,7 @@ dependencies = [
  "lazy_static",
  "lru 0.12.5",
  "mpc-contract 1.0.1",
- "mpc-contract 2.1.0-rc.1",
+ "mpc-contract 2.1.1-rc.1",
  "near-client",
  "near-config-utils 2.6.0-rc.1",
  "near-crypto 2.6.0-rc.1",

--- a/devnet/Cargo.lock
+++ b/devnet/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
  "futures",
  "hex",
  "mpc-contract 1.0.1",
- "mpc-contract 2.1.0-rc.1",
+ "mpc-contract 2.1.1-rc.1",
  "near-crypto 0.28.0",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "2.1.0-rc.1"
+version = "2.1.1-rc.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/libs/chain-signatures/Cargo.lock
+++ b/libs/chain-signatures/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "2.1.0-rc.1"
+version = "2.1.1-rc.1"
 dependencies = [
  "anyhow",
  "borsh",

--- a/libs/chain-signatures/contract/Cargo.toml
+++ b/libs/chain-signatures/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-contract"
-version = "2.1.0-rc.1"
+version = "2.1.1-rc.1"
 edition = "2021"
 
 [lib]

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -455,14 +455,14 @@ impl VersionedMpcContract {
         if !signature_is_valid {
             return Err(RespondError::InvalidSignature.into());
         }
+
+        let Self::V1(mpc_contract) = self else {
+            env::panic_str("expected V1")
+        };
         // First get the yield promise of the (potentially timed out) request.
-        if let Some(YieldIndex { data_id }) = self.get_pending_request(&request) {
+        if let Some(YieldIndex { data_id }) = mpc_contract.pending_requests.remove(&request) {
             // Finally, resolve the promise. This will have no effect if the request already timed.
             env::promise_yield_resume(&data_id, &serde_json::to_vec(&response).unwrap());
-            let Self::V1(mpc_contract) = self else {
-                env::panic_str("expected V1")
-            };
-            mpc_contract.pending_requests.remove(&request);
             Ok(())
         } else {
             Err(InvalidParameters::RequestNotFound.into())

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -49,7 +49,7 @@ const GAS_FOR_SIGN_CALL: Gas = Gas::from_tgas(10);
 // Register used to receive data id from `promise_await_data`.
 const DATA_ID_REGISTER: u64 = 0;
 // Prepaid gas for a `return_signature_and_clean_state_on_success` call
-const RETURN_SIGNATURE_AND_CLEAN_STATE_ON_SUCCESS_CALL_GAS: Gas = Gas::from_tgas(4);
+const RETURN_SIGNATURE_AND_CLEAN_STATE_ON_SUCCESS_CALL_GAS: Gas = Gas::from_tgas(5);
 // Prepaid gas for a `update_config` call
 const UPDATE_CONFIG_GAS: Gas = Gas::from_tgas(5);
 
@@ -459,6 +459,10 @@ impl VersionedMpcContract {
         if let Some(YieldIndex { data_id }) = self.get_pending_request(&request) {
             // Finally, resolve the promise. This will have no effect if the request already timed.
             env::promise_yield_resume(&data_id, &serde_json::to_vec(&response).unwrap());
+            let Self::V1(mpc_contract) = self else {
+                env::panic_str("expected V1")
+            };
+            mpc_contract.pending_requests.remove(&request);
             Ok(())
         } else {
             Err(InvalidParameters::RequestNotFound.into())
@@ -839,10 +843,10 @@ impl VersionedMpcContract {
         let Self::V1(mpc_contract) = self else {
             env::panic_str("expected V1")
         };
-        mpc_contract.pending_requests.remove(&request);
         match signature {
             Ok(signature) => PromiseOrValue::Value(signature),
             Err(_) => {
+                mpc_contract.pending_requests.remove(&request);
                 let promise = Promise::new(env::current_account_id()).function_call(
                     "fail_on_timeout".to_string(),
                     vec![],


### PR DESCRIPTION
Fix to [this discussion](https://nearone.slack.com/archives/C07UW93JVQ8/p1746013523358199?thread_ts=1746005094.777519&cid=C07UW93JVQ8):

- adjust the gas attachment so we don't run out of gas on failure
- move the cleaning mechanism into the `respond` call. This should allow us to remove the hanging request on testnet, but might have its own set of problems.