### PR TITLE
accept re-submitting requests

### DIFF
--- a/libs/chain-signatures/contract/readme.md
+++ b/libs/chain-signatures/contract/readme.md
@@ -48,7 +48,7 @@ stateDiagram-v2
 
 | Function                                                                                     | Behavior                                                                                                 | Return Value               | Gas requirement | Effective Gas Cost |
 | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------- | --------------- | ------------------ |
-| `sign(request: SignRequestArgs)`                                                             | Submits a signature request to the contract. Requires a deposit of 1 yoctonear                           | deferred to promise        | `10 Tgas`       | `~6 Tgas`          |
+| `sign(request: SignRequestArgs)`                                                             | Submits a signature request to the contract. Requires a deposit of 1 yoctonear. Re-submitting the same request before the original request timed out or has been responded to may cause both requests to fail. | deferred to promise        | `10 Tgas`       | `~6 Tgas`          |
 | `public_key(domain: Option<DomainId>)`                                                       | Read-only function; returns the public key used for the given domain (defaulting to first).              | `Result<PublicKey, Error>` |                 |                    |
 | `derived_public_key(path: String, predecessor: Option<AccountId>, domain: Option<DomainId>)` | Generates a derived public key for a given path and account, for the given domain (defaulting to first). | `Result<PublicKey, Error>` |                 |                    |
 

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -96,9 +96,11 @@ impl MpcContract {
         self.protocol_state.threshold()
     }
 
-    fn add_request(&mut self, request: &SignatureRequest, data_id: CryptoHash) {
+    // returns true if the request was already pending
+    fn add_request(&mut self, request: &SignatureRequest, data_id: CryptoHash) -> bool {
         self.pending_requests
-            .insert(request.clone(), YieldIndex { data_id });
+            .insert(request.clone(), YieldIndex { data_id })
+            .is_some()
     }
 
     fn get_pending_request(&self, request: &SignatureRequest) -> Option<YieldIndex> {
@@ -286,11 +288,6 @@ impl VersionedMpcContract {
             env::panic_str("expected V1")
         };
 
-        // Check if the request already exists.
-        if mpc_contract.pending_requests.contains_key(&request) {
-            env::panic_str(&SignError::PayloadCollision.to_string());
-        }
-
         env::log_str(&serde_json::to_string(&near_sdk::env::random_seed_array()).unwrap());
 
         let promise_index = env::promise_yield_create(
@@ -306,7 +303,9 @@ impl VersionedMpcContract {
             .expect("read_register failed")
             .try_into()
             .expect("conversion to CryptoHash failed");
-        mpc_contract.add_request(&request, return_sig_id);
+        if mpc_contract.add_request(&request, return_sig_id) {
+            log!("request already present, overriding callback.")
+        }
 
         env::promise_return(promise_index);
     }

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -96,7 +96,7 @@ impl MpcContract {
         self.protocol_state.threshold()
     }
 
-    // returns true if the request was already pending
+    /// returns true if the request was already pending
     fn add_request(&mut self, request: &SignatureRequest, data_id: CryptoHash) -> bool {
         self.pending_requests
             .insert(request.clone(), YieldIndex { data_id })

--- a/pytest/tests/test_contract_update.py
+++ b/pytest/tests/test_contract_update.py
@@ -228,6 +228,7 @@ def test_update_v2_running():
                         ignore_vote_errors=True)
     cluster.send_and_await_signature_requests(1)
 
+    time.sleep(1)
     # introduce some state:
     args = {
         'prospective_epoch_id': 1,


### PR DESCRIPTION
Unfortunately, the cleanup function that was supposed to clear the state from timed out requests ran out of gas (c.f. #380 ).
This means that any signature requests that timed out since the latest release will remain in the state indefinitely, preventing the user from submitting the same request again.

This PR allows the user to re-submit signature requests. This guarantees to remove the request from the state, because:
 - either the MPC network will submit a signature response and remove the request from the state,
 - or the request will time out and be removed from the state in the cleanup function.


**But beware!** Re-submitting the same request before the time-out duration of 200 blocks has passed, or a response has been submitted, risks to result in another timed-out request. That is because the previous return promise would remove the request from the state and thus any attempt at responding to it will fail.

Timeline of edge case:
t0: submit request, cleanup-promise p0 [is generated](https://github.com/Near-One/mpc/blob/83e0970a3e7428011d3ab1fb7bbd916fdc0e299f/libs/chain-signatures/contract/src/lib.rs#L296)
t1: re-submit request, cleanup promise p1 is generated
t2: cleanup-promise p0 is triggered, [removing the request from the state](https://github.com/Near-One/mpc/blob/83e0970a3e7428011d3ab1fb7bbd916fdc0e299f/libs/chain-signatures/contract/src/lib.rs#L849)
t3: MPC network submits signature response to request from t1. Fails, because it is no longer in the state
t4: cleanup promise p1 is triggered.