### PR TITLE
Hotfix for cait-sith memory leak.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/Near-One/cait-sith?rev=5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5#5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5"
+source = "git+https://github.com/Near-One/cait-sith?rev=68d38188468733dd890dabd8d35b8b7a011e71dd#68d38188468733dd890dabd8d35b8b7a011e71dd"
 dependencies = [
  "auto_ops",
  "ck-meow",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.92"
 async-trait = "0.1.83"
 axum = "0.7.9"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/Near-One/cait-sith", rev = "5e0ce40a16dc3e0889277f66bb2a6400d6ef36a5", features = [
+cait-sith = { git = "https://github.com/Near-One/cait-sith", rev = "68d38188468733dd890dabd8d35b8b7a011e71dd", features = [
     "k256",
 ] }
 clap = { version = "4.5.20", features = ["derive", "env"] }


### PR DESCRIPTION
Apply Robin's #389 to `main`. It is in [testnet-release](https://github.com/Near-One/mpc/tree/testnet-release) at the moment