### PR TITLE
30s timeout for incoming connections

### DIFF
--- a/node/src/network/constants.rs
+++ b/node/src/network/constants.rs
@@ -2,3 +2,6 @@
 /// to prevent a malicious node from sending a huge message that would
 /// cause OOM errors.
 pub const MAX_MESSAGE_LEN: u32 = 100 * 1024 * 1024;
+/// Timeout in seconds for reading messages from the network peers.
+/// This is to prevent hanging peer connections.
+pub const MESSAGE_READ_TIMEOUT_SECS: u64 = 30;

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -449,12 +449,18 @@ pub async fn new_tls_mesh_network(
                     .set_incoming_connection(&incoming_conn);
                 let mut received_bytes: u64 = 0;
                 loop {
-                    let len = stream.read_u32().await?;
+                    let len = tokio::time::timeout(
+                        std::time::Duration::from_secs(30),
+                        stream.read_u32()
+                    ).await??;
                     if len >= MAX_MESSAGE_LEN {
                         anyhow::bail!("Message too long");
                     }
                     let mut buf = vec![0; len as usize];
-                    stream.read_exact(&mut buf).await?;
+                    tokio::time::timeout(
+                        std::time::Duration::from_secs(30),
+                        stream.read_exact(&mut buf)
+                    ).await??;
                     received_bytes += 4 + len as u64;
 
                     let packet =

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -449,18 +449,18 @@ pub async fn new_tls_mesh_network(
                     .set_incoming_connection(&incoming_conn);
                 let mut received_bytes: u64 = 0;
                 loop {
-                    let len = tokio::time::timeout(
-                        std::time::Duration::from_secs(30),
-                        stream.read_u32()
-                    ).await??;
+                    let len =
+                        tokio::time::timeout(std::time::Duration::from_secs(30), stream.read_u32())
+                            .await??;
                     if len >= MAX_MESSAGE_LEN {
                         anyhow::bail!("Message too long");
                     }
                     let mut buf = vec![0; len as usize];
                     tokio::time::timeout(
                         std::time::Duration::from_secs(30),
-                        stream.read_exact(&mut buf)
-                    ).await??;
+                        stream.read_exact(&mut buf),
+                    )
+                    .await??;
                     received_bytes += 4 + len as u64;
 
                     let packet =

--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -2,7 +2,7 @@ use crate::config::MpcConfig;
 use crate::network::conn::{
     AllNodeConnectivities, ConnectionVersion, NodeConnectivity, NodeConnectivityInterface,
 };
-use crate::network::constants::MAX_MESSAGE_LEN;
+use crate::network::constants::{MAX_MESSAGE_LEN, MESSAGE_READ_TIMEOUT_SECS};
 use crate::network::handshake::p2p_handshake;
 use crate::network::{MeshNetworkTransportReceiver, MeshNetworkTransportSender};
 use crate::primitives::{
@@ -449,15 +449,17 @@ pub async fn new_tls_mesh_network(
                     .set_incoming_connection(&incoming_conn);
                 let mut received_bytes: u64 = 0;
                 loop {
-                    let len =
-                        tokio::time::timeout(std::time::Duration::from_secs(30), stream.read_u32())
-                            .await??;
+                    let len = tokio::time::timeout(
+                        std::time::Duration::from_secs(MESSAGE_READ_TIMEOUT_SECS),
+                        stream.read_u32(),
+                    )
+                    .await??;
                     if len >= MAX_MESSAGE_LEN {
                         anyhow::bail!("Message too long");
                     }
                     let mut buf = vec![0; len as usize];
                     tokio::time::timeout(
-                        std::time::Duration::from_secs(30),
+                        std::time::Duration::from_secs(MESSAGE_READ_TIMEOUT_SECS),
                         stream.read_exact(&mut buf),
                     )
                     .await??;


### PR DESCRIPTION
Trying to address https://github.com/Near-One/mpc/issues/388 by adding a 30 seconds timeout for incoming connections.

### Testing:
Docker freeze container at 14:10:05 to simulate a process hang like we had in testnet:
```
andrei@tcptime-nomad-mpc-client-1:~$ sudo docker pause b35c3d2b91a7
b35c3d2b91a7
```

Exactly after 30 seconds logs start reporting computation errors and handle connection 30 seconds::
```
2025-05-22T14:10:30.833307Z  INFO stats: #197970541 HeqBED9iK17ogAtuH7SY2BChXTWtQYgWfprkodTX2kKT 29 validators 10 peers ⬇ 780 kB/s ⬆ 546 kB/s 1.60 bps 14.3 Tgas/s CPU: 25%, Mem: 28.1 GB
2025-05-22T14:10:32.796372Z  INFO indexer: # 197970545 | Blocks processing: 0| Blocks done: 1587. Bps 1.70 b/s 
2025-05-22T14:10:35.328034Z ERROR mpc_node::tracking: Task failed: deadline has elapsed; trace:
  from  5m Handle connection: Received 315391150 bytes from 1 (for 30s)
  from 13m Handle incoming connections:  (for 13m)
  from 13m Running: Running epoch EpochId(0) as participant 0 (for 13m)
  from 100m root: Running (for 13m)
2025-05-22T14:10:35.403651Z ERROR mpc_node::tracking: Task failed: Computation cannot succeed as not all participants are alive anymore; trace:
```

Dropped incoming connection confirmed with netstat:
```
andrei@tcptime-nomad-mpc-client-0:~$ sudo nsenter -t $(sudo docker inspect -f '{{.State.Pid}}' 48939a754a92) -n netstat -tulpna  | grep \:8443 | grep 10.138.0.69
tcp        0      0 172.17.0.2:38954        10.138.0.69:8443        ESTABLISHED 6244/mpc-node
tcp        0      0 172.17.0.2:8443         10.138.0.69:54196       FIN_WAIT2   -
```

Mesh is confirmed broken to peer_participant_id 1:
```
# HELP mpc_network_live_connections Current state of the mesh network connections
# TYPE mpc_network_live_connections gauge
mpc_network_live_connections{my_participant_id="2",peer_participant_id="0"} 1
mpc_network_live_connections{my_participant_id="2",peer_participant_id="1"} 0
mpc_network_live_connections{my_participant_id="2",peer_participant_id="2"} 1
```